### PR TITLE
Fix repeated tokens in alignment

### DIFF
--- a/alignment.py
+++ b/alignment.py
@@ -118,18 +118,19 @@ def build_rows(ref: str, hyp: str) -> List[List]:
         if 0 <= next_i < len(ref_tok) and 0 <= next_j < len(hyp_tok):
             full_pairs.append((next_i, next_j))
 
-    map_h = [-1] * len(ref_tok)
+    # ensure one-to-one mapping and avoid propagating indexes
+    full_pairs.sort()
+    used_h = set()
+    dedup_pairs: List[Tuple[int, int]] = []
     for ri, hj in full_pairs:
+        if hj not in used_h:
+            dedup_pairs.append((ri, hj))
+            used_h.add(hj)
+
+    map_h = [-1] * len(ref_tok)
+    for ri, hj in dedup_pairs:
         if 0 <= ri < len(ref_tok) and 0 <= hj < len(hyp_tok) and map_h[ri] == -1:
             map_h[ri] = hj
-    last = -1
-    for i in range(len(map_h)):
-        if map_h[i] != -1:
-            last = map_h[i]
-        else:
-            if last + 1 < len(hyp_tok):
-                last += 1
-                map_h[i] = last
 
     rows = []
     pos = 0

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -10,6 +10,19 @@ def test_token_equal_digit_word():
     assert not text_utils.token_equal("1", "dos")
 
 
+def test_token_equal_punctuation():
+    assert text_utils.token_equal(".", "punto")
+    assert text_utils.token_equal(",", "coma")
+    assert text_utils.token_equal(";", "punto y coma")
+
+
+def test_normalize_punctuation_word():
+    out = text_utils.normalize("hola punto adios", strip_punct=False)
+    assert out == "hola . adios"
+    out = text_utils.normalize("bien punto y coma mal", strip_punct=False)
+    assert out == "bien ; mal"
+
+
 def test_find_anchor_trigrams():
     ref = "a b c d e f".split()
     hyp = "x a b c y d e f".split()


### PR DESCRIPTION
## Summary
- treat spelled out punctuation as punctuation
- deduplicate alignments and avoid propagating indices
- expand stop words
- test punctuation equivalence
- handle 'punto y coma'

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842d54bf1ac832a8a3567a7c1e988aa