### PR TITLE
Implement alignment improvements

### DIFF
--- a/alignment.py
+++ b/alignment.py
@@ -107,26 +107,35 @@ def build_rows(ref: str, hyp: str) -> List[List]:
     anchor_pairs = find_anchor_trigrams(ref_tok, hyp_tok)
 
     full_pairs: List[Tuple[int, int]] = []
-    seg_starts = [(-1, -1)] + anchor_pairs + [(len(ref_tok) - 1, len(hyp_tok) - 1)]
+    seg_starts = [(-1, -1)] + anchor_pairs + [
+        (len(ref_tok) - 1, len(hyp_tok) - 1)
+    ]
     for (prev_i, prev_j), (next_i, next_j) in zip(seg_starts[:-1], seg_starts[1:]):
         if next_i > prev_i + 1 and next_j > prev_j + 1:
             sub_ref = ref_tok[prev_i + 1 : next_i]
             sub_hyp = hyp_tok[prev_j + 1 : next_j]
             if sub_ref and sub_hyp:
-                pairs = safe_dtw(sub_ref, sub_hyp, COARSE_W)
+                # remove stop words for alignment but keep position maps
+                ref_idx = [i for i, t in enumerate(sub_ref) if t not in STOP]
+                hyp_idx = [j for j, t in enumerate(sub_hyp) if t not in STOP]
+                sub_r_sw = [sub_ref[i] for i in ref_idx]
+                sub_h_sw = [sub_hyp[j] for j in hyp_idx]
+                pairs = safe_dtw(sub_r_sw, sub_h_sw, COARSE_W)
                 for ri, hj in pairs:
-                    full_pairs.append((prev_i + 1 + ri, prev_j + 1 + hj))
+                    full_pairs.append(
+                        (prev_i + 1 + ref_idx[ri], prev_j + 1 + hyp_idx[hj])
+                    )
         if 0 <= next_i < len(ref_tok) and 0 <= next_j < len(hyp_tok):
             full_pairs.append((next_i, next_j))
 
     # ensure one-to-one mapping and avoid propagating indexes
     full_pairs.sort()
-    used_h = set()
+    used_h: dict[int, int] = {}
     dedup_pairs: List[Tuple[int, int]] = []
     for ri, hj in full_pairs:
-        if hj not in used_h:
+        if hj not in used_h or abs(ri - used_h[hj]) > 1:
             dedup_pairs.append((ri, hj))
-            used_h.add(hj)
+            used_h[hj] = ri
 
     map_h = [-1] * len(ref_tok)
     for ri, hj in dedup_pairs:
@@ -137,15 +146,38 @@ def build_rows(ref: str, hyp: str) -> List[List]:
     pos = 0
     line_id = 0
     while pos < len(ref_tok):
-        block = ref_tok[pos : pos + LINE_LEN]
+        max_end = min(pos + LINE_LEN, len(ref_tok))
+        span_end = max_end
+        for k in range(pos, max_end):
+            tok = ref_tok[k]
+            if tok.endswith(".") or tok in {".", "?", "!"}:
+                span_end = k + 1
+                break
+            if tok.endswith(",") or tok.endswith(";") or tok in {",", ";"}:
+                add = 2 if k + 1 < len(ref_tok) and k + 2 - pos <= LINE_LEN else 1
+                span_end = min(k + add, max_end)
+                break
+        block = ref_tok[pos:span_end]
         span_start = pos
-        span_end = pos + len(block)
         pos = span_end
 
         h_idxs = [map_h[k] for k in range(span_start, span_end) if map_h[k] != -1]
         if h_idxs:
             h_start = min(h_idxs)
             h_end = max(h_idxs) + 1
+            # backfill up to two preceding stop words
+            for _ in range(2):
+                if h_start > 0 and hyp_tok[h_start - 1] in STOP:
+                    h_start -= 1
+                else:
+                    break
+            # extend for unmapped ref tokens
+            missing = sum(1 for k in range(span_start, span_end) if map_h[k] == -1)
+            for _ in range(missing):
+                if h_start > 0 and hyp_tok[h_start - 1] not in {".", ";"}:
+                    h_start -= 1
+                else:
+                    break
             asr_line = " ".join(hyp_tok[h_start:h_end])
         else:
             asr_line = ""

--- a/text_utils.py
+++ b/text_utils.py
@@ -108,6 +108,21 @@ def token_equal(a: str, b: str) -> bool:
 
     if a == b:
         return True
+    # handle abbreviations like "r." vs "r"
+    if (
+        len(a) == 2
+        and a[1] == "."
+        and a[0].isalpha()
+        and len(b) == 1
+        and b == a[0]
+    ) or (
+        len(b) == 2
+        and b[1] == "."
+        and b[0].isalpha()
+        and len(a) == 1
+        and a == b[0]
+    ):
+        return True
     # consider punctuation words equivalent to symbols
     punct_map = {
         ".": {"punto", "puntos"},


### PR DESCRIPTION
## Summary
- normalize abbreviations like `r.` and `r` in `token_equal`
- remove stopwords before DTW and track index mapping
- relax deduplication rules for repeated initials
- allow variable reference block segmentation
- backfill stop words and missing tokens when generating ASR lines

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842dfa339f0832a8e912d2f6970e8f8