### PR TITLE
Implement alignment improvements

### DIFF
--- a/text_utils.py
+++ b/text_utils.py
@@ -108,6 +108,21 @@ def token_equal(a: str, b: str) -> bool:
 
     if a == b:
         return True
+    # handle abbreviations like "r." vs "r"
+    if (
+        len(a) == 2
+        and a[1] == "."
+        and a[0].isalpha()
+        and len(b) == 1
+        and b == a[0]
+    ) or (
+        len(b) == 2
+        and b[1] == "."
+        and b[0].isalpha()
+        and len(a) == 1
+        and a == b[0]
+    ):
+        return True
     # consider punctuation words equivalent to symbols
     punct_map = {
         ".": {"punto", "puntos"},


### PR DESCRIPTION
## Summary
- normalize abbreviations like `r.` and `r` in `token_equal`
- remove stopwords before DTW and track index mapping
- relax deduplication rules for repeated initials
- allow variable reference block segmentation
- backfill stop words and missing tokens when generating ASR lines
- consume ASR indices per row to prevent duplication

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842dfa339f0832a8e912d2f6970e8f8