### PR TITLE
Add manual review docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,15 @@ Run the GUI with:
 python qc_app.py
 ```
 
-The application lets you select a script (PDF or TXT) and an ASR transcript, performs alignment and saves a `.qc.json` file.
+The application lets you select a script (PDF or TXT) and an ASR transcript,
+performs alignment and saves a `.qc.json` file.
+
+## Manual review
+
+Double-click the **OK** column in the results table to mark or unmark a row as
+reviewed. Use the **Guardar JSON** button to save the current table so these
+marks persist. Loading a previously saved file that includes an **OK** column
+will restore the review status for each row.
 
 ## Implementation notes
 


### PR DESCRIPTION
## Summary
- document how to mark rows as reviewed in the GUI
- mention **Guardar JSON** for persisting review status
- note that saved files with an `OK` column restore the marks

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842e7c36f88832a883118ed4ac49ab6