### PR TITLE
Add GUI save/load test

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -137,6 +137,26 @@ class App(tk.Tk):
             traceback.print_exc(file=buf)
             self.q.put(buf.getvalue())
 
+    def save_json(self) -> None:
+        """Save current table rows to ``v_json`` path."""
+
+        if not self.v_json.get():
+            p = filedialog.asksaveasfilename(
+                filetypes=[("QC JSON", "*.qc.json;*.json")],
+                defaultextension=".json",
+            )
+            if not p:
+                return
+            self.v_json.set(p)
+        try:
+            rows = [list(self.tree.item(i)["values"]) for i in self.tree.get_children()]
+            Path(self.v_json.get()).write_text(
+                json.dumps(rows, ensure_ascii=False, indent=2), encoding="utf8"
+            )
+            self.log_msg(f"✔ Guardado {self.v_json.get()}")
+        except Exception as e:
+            messagebox.showerror("Error", str(e))
+
     def load_json(self) -> None:
         if not self.v_json.get():
             p = filedialog.askopenfilename(filetypes=[("QC JSON", "*.qc.json;*.json")])

--- a/tests/test_gui_save_load.py
+++ b/tests/test_gui_save_load.py
@@ -1,0 +1,30 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import tkinter as tk
+import tempfile
+
+from gui import App
+
+
+def test_save_load_ok_status():
+    app = App()
+    try:
+        sample = [0, "✅", "", 0.0, 0.0, "hola", "hola"]
+        app.tree.insert("", "end", values=sample)
+        app.update_idletasks()
+        item = app.tree.get_children()[0]
+        # toggle OK manually to avoid GUI event complexity
+        app.tree.set(item, "OK", "OK")
+        app.ok_rows.add(int(app.tree.set(item, "ID")))
+        assert app.tree.set(item, "OK") == "OK"
+        with tempfile.TemporaryDirectory() as td:
+            path = os.path.join(td, "tmp.json")
+            app.v_json.set(path)
+            app.save_json()
+            app.clear_table()
+            app.load_json()
+            loaded = app.tree.get_children()[0]
+            assert app.tree.set(loaded, "OK") == "OK"
+    finally:
+        app.destroy()


### PR DESCRIPTION
## Summary
- implement `App.save_json()` to persist table rows
- add test to verify OK status persists after save/load

## Testing
- `xvfb-run -a pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842e7c74a94832a90b685b88d0f4376