### PR TITLE
Fix lint errors and tests

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -33,13 +33,17 @@ class App(tk.Tk):
         ttk.Button(
             top,
             text="…",
-            command=lambda: self.browse(self.v_ref, ("PDF/TXT", "*.pdf;*.txt")),
+            command=lambda: self.browse(
+                self.v_ref, ("PDF/TXT", "*.pdf;*.txt")
+            ),
         ).grid(row=0, column=2)
 
         ttk.Label(top, text="TXT ASR:").grid(row=1, column=0, sticky="e")
         ttk.Entry(top, textvariable=self.v_asr, width=70).grid(row=1, column=1)
         ttk.Button(
-            top, text="…", command=lambda: self.browse(self.v_asr, ("TXT", "*.txt"))
+            top,
+            text="…",
+            command=lambda: self.browse(self.v_asr, ("TXT", "*.txt")),
         ).grid(row=1, column=2)
 
         ttk.Button(top, text="Procesar", width=11, command=self.launch).grid(
@@ -47,7 +51,9 @@ class App(tk.Tk):
         )
 
         ttk.Label(top, text="JSON:").grid(row=2, column=0, sticky="e")
-        ttk.Entry(top, textvariable=self.v_json, width=70).grid(row=2, column=1)
+        ttk.Entry(top, textvariable=self.v_json, width=70).grid(
+            row=2, column=1
+        )
         ttk.Button(top, text="Abrir JSON…", command=self.load_json).grid(
             row=2, column=2
         )
@@ -68,7 +74,9 @@ class App(tk.Tk):
 
         self.tree.bind("<Double-1>", self._toggle_ok)
 
-        self.log_box = scrolledtext.ScrolledText(self, height=5, state="disabled")
+        self.log_box = scrolledtext.ScrolledText(
+            self, height=5, state="disabled"
+        )
         self.log_box.pack(fill="x", padx=3, pady=2)
 
         self.after(250, self._poll)
@@ -119,7 +127,9 @@ class App(tk.Tk):
             ref = read_script(self.v_ref.get())
 
             self.q.put("→ TXT externo cargado")
-            hyp = Path(self.v_asr.get()).read_text(encoding="utf8", errors="ignore")
+            hyp = Path(self.v_asr.get()).read_text(
+                encoding="utf8", errors="ignore"
+            )
 
             self.q.put("→ Alineando…")
             rows = build_rows(ref, hyp)
@@ -139,12 +149,16 @@ class App(tk.Tk):
 
     def load_json(self) -> None:
         if not self.v_json.get():
-            p = filedialog.askopenfilename(filetypes=[("QC JSON", "*.qc.json;*.json")])
+            p = filedialog.askopenfilename(
+                filetypes=[("QC JSON", "*.qc.json;*.json")]
+            )
             if not p:
                 return
             self.v_json.set(p)
         try:
-            rows = json.loads(Path(self.v_json.get()).read_text(encoding="utf8"))
+            rows = json.loads(
+                Path(self.v_json.get()).read_text(encoding="utf8")
+            )
             self.clear_table()
             for r in rows:
                 if len(r) == 6:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -1,6 +1,3 @@
-import sys, os
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-
 from alignment import build_rows
 
 

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -1,6 +1,3 @@
-import sys, os
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-
 import text_utils
 
 

--- a/text_utils.py
+++ b/text_utils.py
@@ -168,8 +168,12 @@ def find_anchor_trigrams(
     for tri in hyp_trigs:
         freq_hyp[tri] = freq_hyp.get(tri, 0) + 1
 
-    lowfreq_ref = {tri for tri, count in freq_ref.items() if count <= ANCHOR_MAX_FREQ}
-    lowfreq_hyp = {tri for tri, count in freq_hyp.items() if count <= ANCHOR_MAX_FREQ}
+    lowfreq_ref = {
+        tri for tri, count in freq_ref.items() if count <= ANCHOR_MAX_FREQ
+    }
+    lowfreq_hyp = {
+        tri for tri, count in freq_hyp.items() if count <= ANCHOR_MAX_FREQ
+    }
     candidate_trigs = lowfreq_ref.intersection(lowfreq_hyp)
 
     anchors: List[Tuple[int, int]] = []


### PR DESCRIPTION
## Summary
- reformat long lines to under 79 chars
- fix E203 spacing in slices
- tweak GUI code formatting
- adjust tests to import project modules via conftest
- add conftest for path setup

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842e7c913a0832aafc341bd045b73fe