### PR TITLE
Improve segmentation and normalization

### DIFF
--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -6,3 +6,11 @@ def test_build_rows_basic():
     hyp = "hola mundo"
     rows = build_rows(ref, hyp)
     assert rows[0][1] == "✅"
+
+
+def test_build_rows_sentence_split():
+    ref = "Hola mundo. Adios."
+    hyp = "Hola mundo. Adios."
+    rows = build_rows(ref, hyp)
+    assert len(rows) == 2
+    assert all(r[1] == "✅" for r in rows)

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -25,3 +25,7 @@ def test_find_anchor_trigrams():
     hyp = "x a b c y d e f".split()
     anchors = text_utils.find_anchor_trigrams(ref, hyp)
     assert anchors == [(3, 5)]
+
+
+def test_token_equal_accents_case():
+    assert text_utils.token_equal("Árbol", "arbol")


### PR DESCRIPTION
## Summary
- improve `normalize` by dropping single-letter periods
- make `token_equal` accent-insensitive
- split `build_rows` based on sentence boundaries
- adjust WER flag thresholds and add punctuation-insensitive check
- add tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684312c80258832a9ab1a217c5203dec