### PR TITLE
Remove style options from tag_configure call

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -121,7 +121,8 @@ class App(tk.Tk):
 
         self.tree.tag_configure(self.tree_tag, background="#d0e0ff")
         self.tree.tag_configure(
-            self.merged_tag, background="#f5f5f5", relief="solid", borderwidth=2
+            self.merged_tag,
+            background="#f5f5f5",
         )
 
         self.menu = tk.Menu(self, tearoff=0)


### PR DESCRIPTION
## Summary
- clean up tag_configure usage in `gui.py`

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_684acd3b1dd4832ab47decdeaf420d9c