### PR TITLE
Add debugging logs and .env support for OpenAI API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 .pytest_cache/
 .DS_Store
+.env

--- a/README.md
+++ b/README.md
@@ -49,3 +49,17 @@ word-level Levenshtein distance.
 With a JSON file loaded you can click **AI Review (o3)** to send unchecked lines
 to OpenAI and automatically fill the *AI* column with `ok`, `mal` or `dudoso`.
 Lines marked `ok` are also auto-approved.
+
+### OpenAI setup
+
+This project uses the OpenAI Python client (v1+) for AI review.
+Set your API key in the OPENAI_API_KEY environment variable.
+You can create a .env file with the key and optional debugging flag:
+
+```
+OPENAI_API_KEY=sk-yourkey
+AI_REVIEW_DEBUG=1
+```
+
+The .env file is ignored by git so your credentials remain private.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ faster-whisper
 torch
 tqdm
 openai>=1.2.0
+python-dotenv


### PR DESCRIPTION
## Summary
- introduce `.env` handling and debug logging in `ai_review`
- ignore `.env` in git
- document OpenAI key setup in README
- include `python-dotenv` in requirements

## Testing
- `flake8` *(fails: E402, E501, E203, E303, E731...)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ad4dbe064832aafcb51fe1034d02e