### PR TITLE
Fix AI column persistence

### DIFF
--- a/ai_review.py
+++ b/ai_review.py
@@ -125,6 +125,8 @@ def review_row(row: List, base_prompt: str | None = None) -> str:
     """Annotate a single QC row with AI verdict."""
     orig, asr = row[-2], row[-1]
     verdict = ai_verdict(str(orig), str(asr), base_prompt)
+    if verdict not in {"ok", "mal", "dudoso"}:
+        verdict = "dudoso"
     # Insert into row preserving structure
     # Row formats: [ID, tick, OK?, WER, dur, original, asr]
     if len(row) == 6:
@@ -152,6 +154,8 @@ def review_file(qc_json: str, prompt_path: str = "prompt.txt") -> tuple[int,int]
             continue
         sent += 1
         verdict = ai_verdict(str(row[-2]), str(row[-1]), prompt)
+        if verdict not in {"ok", "mal", "dudoso"}:
+            verdict = "dudoso"
         # Insert verdict column
         if len(row) == 6:
             row.insert(2,"")

--- a/gui.py
+++ b/gui.py
@@ -568,6 +568,7 @@ class App(tk.Tk):
                             self.ok_rows.add(line_id)
                         except Exception:
                             pass
+                    self.save_json()
                 else:
                     self.log_msg(str(msg))
         except queue.Empty:


### PR DESCRIPTION
## Summary
- ensure manual AI review persists by saving after AI_ROW is processed
- safeguard `review_row` and `review_file` when OpenAI returns unexpected text

## Testing
- `flake8 ai_review.py gui.py | head`
- `pytest tests/test_ai_review.py::test_review_file_bad_response_mark_dudoso -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b262cff68832ab682c35f8e780289