### PR TITLE
Add stop functionality to AI review in GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ word-level Levenshtein distance.
 
 With a JSON file loaded you can click **AI Review (o3)** to send unchecked lines
 to OpenAI and automatically fill the *AI* column with `ok`, `mal` or `dudoso`.
-Lines marked `ok` are also auto-approved.
+Lines marked `ok` are also auto-approved. Use **Detener análisis** to interrupt
+the batch review if needed.
 
 ### OpenAI setup
 

--- a/tests/test_gui_stop_button.py
+++ b/tests/test_gui_stop_button.py
@@ -1,0 +1,35 @@
+import sys
+import os
+import threading
+import time
+import pytest
+from unittest import mock
+
+if not os.environ.get("DISPLAY"):
+    pytest.skip("no display", allow_module_level=True)
+
+from gui import App
+import ai_review
+
+
+def test_stop_button_interrupts_review():
+    app = App()
+    start_event = threading.Event()
+    finish_event = threading.Event()
+
+    def slow_review(path):
+        ai_review._stop_review = False
+        start_event.set()
+        while not ai_review._stop_review:
+            time.sleep(0.01)
+        finish_event.set()
+        return 0, 0
+
+    with mock.patch("ai_review.review_file", side_effect=slow_review):
+        t = threading.Thread(target=app._ai_review_worker)
+        t.start()
+        assert start_event.wait(1)
+        app.stop_ai_review()
+        t.join(timeout=1)
+        assert finish_event.is_set()
+    app.destroy()


### PR DESCRIPTION
## Summary
- add **Detener análisis** button to GUI
- implement `stop_ai_review` and handle `_stop_review` flag
- test stopping the review from GUI
- document stop button in README

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c3096e468832a98ba606cd5356a4f