### PR TITLE
Fix AI review skipping

### DIFF
--- a/ai_review.py
+++ b/ai_review.py
@@ -241,7 +241,8 @@ def review_file(qc_json: str, prompt_path: str = "prompt.txt") -> tuple[int,int]
         tick = row[1] if len(row) > 1 else ""
         ok = row[2] if len(row) >= 7 else ""
         ai = row[3] if len(row) >= 8 else ""
-        if tick == "✅" or ok.lower() == "ok" or ai.lower() == "ok":
+        # Skip rows already reviewed by AI regardless of verdict
+        if tick == "✅" or ok.lower() == "ok" or ai:
             continue
         sent += 1
         try:
@@ -294,7 +295,8 @@ def review_file_feedback(
         tick = row[1] if len(row) > 1 else ""
         ok = row[2] if len(row) >= 7 else ""
         ai = row[3] if len(row) >= 8 else ""
-        if tick == "✅" or ok.lower() == "ok" or ai.lower() == "ok":
+        # Skip rows already reviewed by AI regardless of verdict
+        if tick == "✅" or ok.lower() == "ok" or ai:
             continue
         sent += 1
         try:

--- a/tests/test_ai_review.py
+++ b/tests/test_ai_review.py
@@ -76,6 +76,18 @@ def test_review_file_on_eight_column_rows(tmp_path):
     assert data[0][3] == "mal"
 
 
+def test_review_file_skips_existing_ai_verdict(tmp_path):
+    rows = [[0, "", "", "mal", 10.0, 0.5, "hola", "hola"]]
+    path = tmp_path / "rows_skip.json"
+    path.write_text(json.dumps(rows, ensure_ascii=False), encoding="utf8")
+    with mock.patch("ai_review.ai_verdict") as m:
+        approved, remaining = ai_review.review_file(str(path))
+    assert m.call_count == 0
+    out = json.loads(path.read_text())
+    assert out[0][3] == "mal"
+    assert approved == 0 and remaining == 0
+
+
 def test_backup_created_and_partial_save(tmp_path):
     rows = [
         [0, "", "", 0, 0, "hola", "hola"],


### PR DESCRIPTION
## Summary
- avoid re-processing rows that already include an AI verdict
- test that review_file skips rows with any existing verdict

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c4d5bc1a0832aa57ccd40aa119e2d