### PR TITLE
Add navigation arrows for AI flagged rows

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -187,6 +187,16 @@ class App(tk.Tk):
             self.play_frame, text="▶", command=self._play_current_clip
         )
         self.play_button.pack(side="left", padx=4, pady=4)
+        ttk.Button(
+            self.play_frame,
+            text="←",
+            command=self._prev_bad_row,
+        ).pack(side="left", padx=4)
+        ttk.Button(
+            self.play_frame,
+            text="→",
+            command=self._next_bad_row,
+        ).pack(side="left", padx=4)
         ttk.Button(self.play_frame, text="OK", command=self._clip_ok).pack(
             side="left", padx=4
         )
@@ -282,6 +292,39 @@ class App(tk.Tk):
             self.tree.set(self._clip_item, "AI", "mal")
             self.save_json()
         self._hide_clip()
+
+    def _next_bad_row(self) -> None:
+        """Jump to the next row where the AI column is ``"mal"``."""
+        children = list(self.tree.get_children())
+        if not children:
+            return
+        start = 0
+        if self._clip_item and self._clip_item in children:
+            start = children.index(self._clip_item) + 1
+        for iid in children[start:] + children[:start]:
+            if self.tree.set(iid, "AI") == "mal":
+                self.tree.see(iid)
+                self._play_clip(iid)
+                return
+
+    def _prev_bad_row(self) -> None:
+        """Jump to the previous row where the AI column is ``"mal"``."""
+        children = list(self.tree.get_children())
+        if not children:
+            return
+        start = len(children) - 1
+        if self._clip_item and self._clip_item in children:
+            start = children.index(self._clip_item) - 1
+        for iid in reversed(children[: start + 1]):
+            if self.tree.set(iid, "AI") == "mal":
+                self.tree.see(iid)
+                self._play_clip(iid)
+                return
+        for iid in reversed(children[start + 1 :]):
+            if self.tree.set(iid, "AI") == "mal":
+                self.tree.see(iid)
+                self._play_clip(iid)
+                return
 
     def _hide_clip(self) -> None:
         try:

--- a/tests/test_gui_navigation.py
+++ b/tests/test_gui_navigation.py
@@ -1,0 +1,31 @@
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+if not os.environ.get("DISPLAY"):
+    pytest.skip("no display", allow_module_level=True)
+
+from gui import App
+
+
+def test_navigation_bad_rows():
+    app = App()
+    try:
+        rows = [
+            [0, "", "", "", "1.0", "uno", "uno"],
+            [1, "", "mal", "", "1.0", "dos", "dos"],
+            [2, "", "", "", "1.0", "tres", "tres"],
+        ]
+        for r in rows:
+            app.tree.insert("", "end", values=r)
+        first = app.tree.get_children()[0]
+        app._play_clip(first)
+        app._next_bad_row()
+        bad = app.tree.get_children()[1]
+        assert app._clip_item == bad
+        app._prev_bad_row()
+        assert app._clip_item == bad
+    finally:
+        app.destroy()


### PR DESCRIPTION
## Summary
- add arrow buttons to jump between rows flagged `mal`
- implement `_next_bad_row` and `_prev_bad_row`
- test navigation helpers

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c700f1090832aa60f6bd5d8d25da5