### PR TITLE
Add word-level transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ python qc_app.py
 The application lets you select a script (PDF or TXT) and an ASR transcript,
 performs alignment and saves a `.qc.json` file.
 
+### Transcribing audio
+
+You can transcribe media files from the command line:
+
+```bash
+python -m transcriber myaudio.mp3 --model base
+```
+
+Add the `--word-json` flag to generate a `.word.json` file with timestamps for
+every word. You may pass a previous transcript using `--prompt file.txt` to help
+Whisper keep the same wording.
+
 ## Manual review
 
 Double-click the **OK** column in the results table to mark or unmark a row as


### PR DESCRIPTION
## Summary
- add `transcribe_wordlevel` in `transcriber.py` to produce word timestamps
- expose CLI flag `--word-json` and optional `--prompt` to reuse an earlier transcript
- document audio transcription usage in README

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c73ac1080832a8d05cfc1b3b9c5d1