### PR TITLE
Add word-level CLI alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ python qc_app.py
 The application lets you select a script (PDF or TXT) and an ASR transcript,
 performs alignment and saves a `.qc.json` file.
 
+### Command line usage
+
+You can also transcribe from the command line:
+
+```bash
+python -m transcriber myaudio.mp3 --script book.txt
+```
+
+To generate a word-level QC file in one step use `--word-align`:
+
+```bash
+python -m transcriber myaudio.mp3 --script book.txt --word-align
+```
+
+This creates `myaudio.words.qc.json` without overwriting the regular QC file.
+
 ## Manual review
 
 Double-click the **OK** column in the results table to mark or unmark a row as

--- a/tests/test_cli_wordalign.py
+++ b/tests/test_cli_wordalign.py
@@ -1,0 +1,38 @@
+import json
+from pathlib import Path
+import sys
+import types
+
+
+def _get_transcriber():
+    sys.modules.setdefault("torch", types.ModuleType("torch"))
+    fw = types.ModuleType("faster_whisper")
+    fw.WhisperModel = object
+    sys.modules.setdefault("faster_whisper", fw)
+    import importlib
+    return importlib.reload(__import__("transcriber"))
+
+
+def test_cli_word_align(tmp_path, monkeypatch):
+    audio = tmp_path / "aud.wav"
+    audio.write_text("a")
+    script = tmp_path / "book.txt"
+    script.write_text("hola")
+    words_json = tmp_path / "aud.words.json"
+
+    tr = _get_transcriber()
+
+    def fake_transcribe_wordlevel(fp, model_size=None, script_path=None):
+        words_json.write_text('[{"word": "hola"}]', encoding="utf8")
+        return words_json
+
+    monkeypatch.setattr(tr, "transcribe_wordlevel", fake_transcribe_wordlevel)
+    monkeypatch.setattr(tr, "build_rows_wordlevel", lambda ref, words: [[0, "", 0, 0, "hola", "hola"]])
+    monkeypatch.setattr(tr, "read_script", lambda p: "hola")
+
+    tr.main([str(audio), "--script", str(script), "--word-align"])
+
+    out = tmp_path / "aud.word.qc.json"
+    data = json.loads(out.read_text())
+    assert data[0][4] == "hola"
+


### PR DESCRIPTION
## Summary
- allow transcription with word timestamp JSON via `transcribe_wordlevel`
- add `build_rows_wordlevel` helper
- expose `--word-align` flag in `transcriber` CLI
- document CLI usage in README
- test the new CLI option

## Testing
- `flake8 | head`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c799754bc832aba12aa16e1f65545