### PR TITLE
Add QC metadata merging utility

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -625,6 +625,14 @@ class App(tk.Tk):
             rows = build_rows(ref, hyp)
 
             out = Path(self.v_asr.get()).with_suffix(".qc.json")
+            if out.exists():
+                try:
+                    old = json.loads(out.read_text(encoding="utf8"))
+                    from qc_utils import merge_qc_metadata
+
+                    rows = merge_qc_metadata(old, rows)
+                except Exception:
+                    pass
             out.write_text(
                 json.dumps(rows, ensure_ascii=False, indent=2), encoding="utf8"
             )
@@ -691,7 +699,10 @@ class App(tk.Tk):
                 msg = self.q.get_nowait()
                 if isinstance(msg, tuple) and msg[0] == "ROWS":
                     for r in msg[1]:
-                        vals = [r[0], r[1], "", "", r[2], r[3], r[4], r[5]]
+                        if len(r) == 6:
+                            vals = [r[0], r[1], "", "", r[2], r[3], r[4], r[5]]
+                        else:
+                            vals = r
                         vals[6] = str(vals[6])
                         vals[7] = str(vals[7])
                         self.tree.insert("", tk.END, values=vals)

--- a/qc_utils.py
+++ b/qc_utils.py
@@ -1,0 +1,46 @@
+"""Utility functions for QC metadata management."""
+
+from __future__ import annotations
+
+from typing import List
+
+from rapidfuzz.distance import Levenshtein
+
+from text_utils import normalize
+
+
+def merge_qc_metadata(old_rows: List[List], new_rows: List[List]) -> List[List]:
+    """Merge QC columns from ``old_rows`` into ``new_rows``.
+
+    Rows are matched based on the normalized ``Original`` text. If a row in
+    ``new_rows`` is more than 80% similar to one in ``old_rows`` (Levenshtein
+    normalized similarity), the values of the ``✓``, ``OK`` and ``AI`` columns
+    are copied from the old row. Any extra columns beyond ``ASR`` are also
+    preserved if present.
+    """
+
+    merged: List[List] = []
+
+    old_norm = [normalize(str(r[-2])) for r in old_rows]
+
+    for new in new_rows:
+        base = [new[0], new[1], "", "", new[2], new[3], new[4], new[5]]
+        n_norm = normalize(str(new[-2]))
+        best = None
+        best_sim = 0.8
+        for o_norm, o_row in zip(old_norm, old_rows):
+            sim = Levenshtein.normalized_similarity(n_norm, o_norm)
+            if sim > best_sim:
+                best_sim = sim
+                best = o_row
+        if best is not None:
+            if len(best) > 1:
+                base[1] = best[1]
+            if len(best) > 2:
+                base[2] = best[2]
+            if len(best) > 3:
+                base[3] = best[3]
+            if len(best) > 8:
+                base.extend(best[8:])
+        merged.append(base)
+    return merged

--- a/tests/test_qc_utils.py
+++ b/tests/test_qc_utils.py
@@ -1,0 +1,20 @@
+import qc_utils
+
+
+def test_merge_qc_metadata_transfers_fields():
+    old = [[0, "✅", "OK", "mal", 10.0, 0.5, "hola amigos", "hola amigos"]]
+    new = [[0, "❌", 20.0, 1.0, "hola amigo", "hola amigo"]]
+    merged = qc_utils.merge_qc_metadata(old, new)
+    assert merged[0][1] == "✅"
+    assert merged[0][2] == "OK"
+    assert merged[0][3] == "mal"
+    assert merged[0][4] == 20.0
+
+
+def test_merge_qc_metadata_when_different():
+    old = [[0, "✅", "OK", "mal", 10.0, 0.5, "hola", "hola"]]
+    new = [[0, "❌", 20.0, 1.0, "adios mundo", "adios mundo"]]
+    merged = qc_utils.merge_qc_metadata(old, new)
+    assert merged[0][1] == "❌"
+    assert merged[0][2] == ""
+    assert merged[0][3] == ""


### PR DESCRIPTION
## Summary
- add `merge_qc_metadata` helper for reusing QC columns
- use helper in GUI alignment worker when overwriting qc.json
- handle incoming rows with optional metadata
- test metadata merge logic

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c7995e648832a9e9ddff28b48c715