### PR TITLE
Highlight current row in GUI navigation

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -270,6 +270,8 @@ class App(tk.Tk):
         self._clip_item = item
         self._clip_start = start
         self._clip_dur = dur
+        self.tree.selection_set(item)
+        self.tree.focus(item)
 
     def _play_current_clip(self) -> None:
         if not self.v_audio.get() or self._clip_item is None:


### PR DESCRIPTION
## Summary
- select and focus the row when playing a clip so navigation buttons highlight the current row

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: httpx, rapidfuzz, pygame, unidecode)*

------
https://chatgpt.com/codex/tasks/task_e_684c7d2d8a38832abdd7406a0b3ff99b