### PR TITLE
Implement qc navigation/worker for tc

### DIFF
--- a/tests/test_qc_app.py
+++ b/tests/test_qc_app.py
@@ -1,0 +1,75 @@
+import os
+import sys
+import json
+from unittest import mock
+import tempfile
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from qc_app import App, play_interval  # noqa: E402
+
+if not os.environ.get("DISPLAY"):
+    pytest.skip("no display", allow_module_level=True)
+
+
+def _insert_rows(app, rows):
+    for r in rows:
+        app.tree.insert("", "end", values=r)
+
+
+def test_navigation_bad_rows_qc():
+    app = App()
+    try:
+        rows = [
+            [0, "", "", "", "0.0", "uno", "uno"],
+            [1, "", "mal", "", "1.0", "dos", "dos"],
+            [2, "", "", "", "2.0", "tres", "tres"],
+        ]
+        _insert_rows(app, rows)
+        first = app.tree.get_children()[0]
+        app._play_clip(first)
+        app._next_bad_row()
+        bad = app.tree.get_children()[1]
+        assert app._clip_item == bad
+        app._prev_bad_row()
+        assert app._clip_item == bad
+    finally:
+        app.destroy()
+
+
+def test_play_clip_tc(monkeypatch):
+    app = App()
+    try:
+        rows = [
+            [0, "", "", "", "0.0", "uno", "uno"],
+            [1, "", "", "", "1.5", "dos", "dos"],
+        ]
+        _insert_rows(app, rows)
+        app.v_audio.set("dummy")
+        monkeypatch.setattr("qc_app.play_interval", lambda *a, **k: None)
+        first = app.tree.get_children()[0]
+        app._play_clip(first)
+        assert app._clip_start == 0.0
+        assert app._clip_end == 1.5
+    finally:
+        app.destroy()
+
+
+def test_worker_creates_json(tmp_path, monkeypatch):
+    app = App()
+    try:
+        ref = tmp_path / "ref.txt"
+        ref.write_text("hola")
+        hyp = tmp_path / "hyp.txt"
+        hyp.write_text("hola")
+        app.v_ref.set(str(ref))
+        app.v_asr.set(str(hyp))
+        monkeypatch.setattr("qc_app.read_script", lambda p: "hola")
+        monkeypatch.setattr("qc_app.build_rows", lambda r, h: [[0, "", 0.0, "0.0", "hola", "hola"]])
+        app._worker()
+        out = hyp.with_suffix(".qc.json")
+        data = json.loads(out.read_text())
+        assert data[0][-1] == "hola"
+    finally:
+        app.destroy()


### PR DESCRIPTION
## Summary
- port navigation helpers and alignment worker into `qc_app.py`
- rely on `tc` column when calculating clip boundaries
- add tests covering qc app navigation, playback, and worker

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859429b5de4832a9c587ed79c889d91