### PR TITLE
Unify word-level transcription

### DIFF
--- a/tests/test_cli_wordalign.py
+++ b/tests/test_cli_wordalign.py
@@ -18,11 +18,17 @@ def test_cli_word_align(tmp_path, monkeypatch):
     audio.write_text("a")
     script = tmp_path / "book.txt"
     script.write_text("hola")
-    words_json = tmp_path / "aud.words.json"
+    words_json = tmp_path / "aud.word.json"
 
     tr = _get_transcriber()
 
-    def fake_transcribe_wordlevel(fp, model_size=None, script_path=None):
+    def fake_transcribe_wordlevel(
+        fp,
+        model_size=None,
+        script_path=None,
+        *,
+        detailed=False,
+    ):
         words_json.write_text('[{"word": "hola"}]', encoding="utf8")
         return words_json
 


### PR DESCRIPTION
## Summary
- consolidate duplicate `transcribe_wordlevel` implementations
- add `detailed` flag to output segment metadata or flat word list
- update CLI to request detailed data
- fix tests for new `.word.json` extension

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685943081bbc832abe3b0f7fa483377a