### PR TITLE
Add navigation skipping approved rows

### DIFF
--- a/qc_app.py
+++ b/qc_app.py
@@ -422,29 +422,38 @@ class App(tk.Tk):
         self._clip_item = None
 
     def _next_bad_row(self):
-        """Jump to the next row where the AI column is ``"mal"``."""
+        """Jump to the next row marked ``"mal"`` and not already ``"OK"``."""
         children = list(self.tree.get_children())
         if not children:
             return
         start = 0
         if self._clip_item and self._clip_item in children:
             start = children.index(self._clip_item) + 1
-        for iid in children[start:] + children[:start]:
-            if self.tree.set(iid, "AI") == "mal":
+        sequence = children[start:] + children[:start]
+        for iid in sequence:
+            if (
+                self.tree.set(iid, "AI") == "mal"
+                and self.tree.set(iid, "OK") != "OK"
+            ):
                 self.tree.see(iid)
                 self._play_clip(iid)
                 return
 
     def _prev_bad_row(self):
-        """Jump to the previous row where the AI column is ``"mal"``."""
+        """Jump to the previous row marked ``"mal"`` and not ``"OK"``."""
         children = list(self.tree.get_children())
         if not children:
             return
         start = len(children) - 1
         if self._clip_item and self._clip_item in children:
             start = children.index(self._clip_item) - 1
-        for iid in reversed(children[: start + 1]):
-            if self.tree.set(iid, "AI") == "mal":
+        first_part = list(reversed(children[: start + 1]))
+        second_part = list(reversed(children[start + 1:]))
+        for iid in first_part + second_part:
+            if (
+                self.tree.set(iid, "AI") == "mal"
+                and self.tree.set(iid, "OK") != "OK"
+            ):
                 self.tree.see(iid)
                 self._play_clip(iid)
                 return

--- a/tests/test_gui_navigation.py
+++ b/tests/test_gui_navigation.py
@@ -16,16 +16,19 @@ def test_navigation_bad_rows():
         rows = [
             [0, "", "", "", "1.0", "uno", "uno"],
             [1, "", "mal", "", "1.0", "dos", "dos"],
-            [2, "", "", "", "1.0", "tres", "tres"],
+            [2, "", "mal", "", "1.0", "tres", "tres"],
         ]
         for r in rows:
             app.tree.insert("", "end", values=r)
+        # mark first bad row as OK so navigation skips it
+        first_bad = app.tree.get_children()[1]
+        app.tree.set(first_bad, "OK", "OK")
         first = app.tree.get_children()[0]
         app._play_clip(first)
         app._next_bad_row()
-        bad = app.tree.get_children()[1]
-        assert app._clip_item == bad
+        target = app.tree.get_children()[2]
+        assert app._clip_item == target
         app._prev_bad_row()
-        assert app._clip_item == bad
+        assert app._clip_item == target
     finally:
         app.destroy()

--- a/tests/test_qc_app.py
+++ b/tests/test_qc_app.py
@@ -1,13 +1,11 @@
 import os
 import sys
 import json
-from unittest import mock
-import tempfile
 import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from qc_app import App, play_interval  # noqa: E402
+from qc_app import App  # noqa: E402
 
 if not os.environ.get("DISPLAY"):
     pytest.skip("no display", allow_module_level=True)
@@ -24,16 +22,19 @@ def test_navigation_bad_rows_qc():
         rows = [
             [0, "", "", "", "0.0", "uno", "uno"],
             [1, "", "mal", "", "1.0", "dos", "dos"],
-            [2, "", "", "", "2.0", "tres", "tres"],
+            [2, "", "mal", "", "2.0", "tres", "tres"],
         ]
         _insert_rows(app, rows)
+        # mark first bad row as OK
+        first_bad = app.tree.get_children()[1]
+        app.tree.set(first_bad, "OK", "OK")
         first = app.tree.get_children()[0]
         app._play_clip(first)
         app._next_bad_row()
-        bad = app.tree.get_children()[1]
-        assert app._clip_item == bad
+        target = app.tree.get_children()[2]
+        assert app._clip_item == target
         app._prev_bad_row()
-        assert app._clip_item == bad
+        assert app._clip_item == target
     finally:
         app.destroy()
 


### PR DESCRIPTION
## Summary
- skip rows marked `OK` when navigating to next/previous `mal`
- update GUI navigation tests
- update QC app tests to reflect new behaviour

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859521a8260832abc948f85c61d4202