### PR TITLE
Add advanced QC app with retranscription

### DIFF
--- a/qc_app_adv.py
+++ b/qc_app_adv.py
@@ -1,0 +1,819 @@
+from __future__ import annotations
+"""Tkinter GUI for the QC application (v5.3‑tc).
+
+* Usa columna **tc** (time‑code) como instante de INICIO de la frase.
+* Para reproducir un clip se toma el tc de la fila actual y el tc de la
+  fila siguiente (o el final del archivo si no hay siguiente).
+* Se mantiene **toda** la funcionalidad original: transcribe, AI‑review,
+  edición de celdas, undo/redo, fusión, etc.
+"""
+
+import io
+import json
+import os
+import queue
+import sys
+import threading
+import traceback
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pygame
+import tkinter as tk
+from tkinter import filedialog, messagebox, scrolledtext, ttk
+
+from alignment import build_rows
+from text_utils import read_script
+
+# --------------------------------------------------------------------------------------
+# utilidades de audio ------------------------------------------------------------------
+# --------------------------------------------------------------------------------------
+
+def play_interval(path: str, start: float, end: float | None) -> None:
+    """Reproduce *path* desde *start* (seg) hasta *end* (seg) con pygame."""
+
+    pygame.mixer.init()
+    pygame.mixer.music.load(path)
+    pygame.mixer.music.play(start=start)
+    if end is not None:
+        ms = int(max(0.0, end - start) * 1000)
+        tk._default_root.after(ms, pygame.mixer.music.stop)
+
+
+# --------------------------------------------------------------------------------------
+# GUI principal ------------------------------------------------------------------------
+# --------------------------------------------------------------------------------------
+
+class App(tk.Tk):
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("QC‑Audiolibro v5.3‑tc")
+        self.geometry("1850x760")
+
+        # ------------------------- variables de la interfaz --------------------------
+        self.v_ref   = tk.StringVar(self)
+        self.v_asr   = tk.StringVar(self)
+        self.v_audio = tk.StringVar(self)
+        self.v_json  = tk.StringVar(self)
+        self.ai_one  = tk.BooleanVar(self, value=False)
+
+        # Estados internos
+        self.q:   queue.Queue = queue.Queue()
+        self.ok_rows: set[int] = set()
+        self.undo_stack: list[str] = []
+        self.redo_stack: list[str] = []
+        self.merged_rows: dict[str, list[list[str]]] = {}
+        # Store previous ASR texts and confidence for re‑transcribed rows
+        self.prev_asr: dict[str, str] = {}
+        self.asr_confidence: dict[str, float] = {}
+
+        self.selected_cell: tuple[str, str] | None = None
+        self.tree_tag = "sel_cell"
+        self.merged_tag = "merged"
+
+        # Repro
+        self._clip_item: str | None = None
+        self._clip_start = 0.0
+        self._clip_end: float | None = None
+
+        self._build_ui()
+        self.after(250, self._poll)
+
+    # ---------------------------------------------------------------- build UI ------
+    def _build_ui(self) -> None:
+        top = ttk.Frame(self)
+        top.pack(fill="x", padx=3, pady=2)
+
+        # Entradas de archivos -------------------------------------------------------
+        self._lbl_entry(top, "Guion:", self.v_ref, 0, ("PDF/TXT", "*.pdf;*.txt"))
+        self._lbl_entry(top, "TXT ASR:", self.v_asr, 1, ("TXT", "*.txt"))
+        self._lbl_entry(top, "Audio:", self.v_audio, 2,
+                        ("Media", "*.mp3;*.wav;*.m4a;*.flac;*.ogg;*.aac;*.mp4"))
+
+        ttk.Button(top, text="Transcribir", command=self.transcribe).grid(row=2, column=3, padx=6)
+        ttk.Button(top, text="Procesar", width=11, command=self.launch).grid(row=0, column=3, rowspan=2, padx=6)
+
+        ttk.Label(top, text="JSON:").grid(row=3, column=0, sticky="e")
+        ttk.Entry(top, textvariable=self.v_json, width=70).grid(row=3, column=1)
+        ttk.Button(top, text="Abrir JSON…", command=self.load_json).grid(row=3, column=2)
+
+        ttk.Button(top, text="AI Review (o3)", command=self.ai_review).grid(row=3, column=3, padx=6)
+        ttk.Checkbutton(top, text="una fila", variable=self.ai_one).grid(row=3, column=4, padx=4)
+        ttk.Button(top, text="Detener análisis", command=self.stop_ai_review).grid(row=3, column=5, padx=6)
+        ttk.Button(top, text="Re-transcribir mal", command=self.reprocess_bad).grid(row=2, column=4, padx=6)
+
+        # Tabla principal -----------------------------------------------------------
+        self._build_table()
+        self._build_player_bar()
+
+        # Menu contextual y atajos -------------------------------------------
+        self.menu = tk.Menu(self, tearoff=0)
+        self.menu.add_command(
+            label="Mover ↑", command=lambda: self._move_cell("up")
+        )
+        self.menu.add_command(
+            label="Mover ↓", command=lambda: self._move_cell("down")
+        )
+        self.menu.add_separator()
+        self.menu.add_command(
+            label="↑ última palabra", command=lambda: self._move_word("up", "last")
+        )
+        self.menu.add_command(
+            label="↓ última palabra", command=lambda: self._move_word("down", "last")
+        )
+        self.menu.add_command(
+            label="↑ primera palabra", command=lambda: self._move_word("up", "first")
+        )
+        self.menu.add_command(
+            label="↓ primera palabra", command=lambda: self._move_word("down", "first")
+        )
+        self.menu.add_separator()
+        self.menu.add_command(
+            label="Fusionar filas seleccionadas", command=self._merge_selected_rows
+        )
+        self.menu.add_command(label="Desagrupar fila", command=self._unmerge_row)
+        self.menu.add_separator()
+        self.menu.add_command(label="Alternar ASR", command=self._toggle_asr)
+
+        self.bind_all("<Control-z>", self.undo)
+        self.bind_all("<Control-Shift-Z>", self.redo)
+
+        # Cuadro de log -------------------------------------------------------
+        self.log_box = scrolledtext.ScrolledText(self, height=5, state="disabled")
+        self.log_box.pack(fill="x", padx=3, pady=2)
+
+        # Eventos de tabla ----------------------------------------------------
+        self.tree.bind("<Button-1>", self._cell_click)
+        self.tree.bind("<Button-3>", self._popup_menu)
+        self.tree.bind("<Double-1>", self._handle_double)
+
+        style = ttk.Style(self)
+        style.configure("Treeview", rowheight=45)
+
+        # instantánea inicial para undo --------------------------------------
+        self._snapshot()
+
+    def _lbl_entry(self, parent, text, var, row, ft):
+        ttk.Label(parent, text=text).grid(row=row, column=0, sticky="e")
+        ttk.Entry(parent, textvariable=var, width=70).grid(row=row, column=1)
+        ttk.Button(parent, text="…", command=lambda: self._browse(var, ft)).grid(row=row, column=2)
+
+    # ---------------------------------------------------------------- table ----------
+    def _build_table(self) -> None:
+        cols = ("ID", "✓", "OK", "AI", "WER", "tc", "Original", "ASR")
+        widths = (50, 30, 40, 40, 60, 60, 800, 800)
+
+        table_frame = ttk.Frame(self)
+        table_frame.pack(fill="both", expand=True, padx=3, pady=2)
+
+        self.tree = ttk.Treeview(table_frame, columns=cols, show="headings", height=27, selectmode="extended")
+        for c, w in zip(cols, widths):
+            self.tree.heading(c, text=c)
+            self.tree.column(c, width=w, anchor="w")
+        self.tree.pack(fill="both", expand=True, side="left")
+        sb = ttk.Scrollbar(table_frame, orient="vertical", command=self.tree.yview)
+        self.tree.configure(yscrollcommand=sb.set)
+        sb.pack(side="right", fill="y")
+
+        self.tree.tag_configure("sel_cell", background="#d0e0ff")
+        self.tree.tag_configure("merged", background="#f5f5f5")
+
+        # bindings
+        self.tree.bind("<Double-1>", self._handle_double)
+
+    # ------------------------------------------------------------- player bar -------
+    def _build_player_bar(self) -> None:
+        bar = ttk.Frame(self)
+        bar.pack(side="top", anchor="ne", padx=4, pady=4)
+        ttk.Button(bar, text="▶", command=self._play_current_clip).pack(side="left", padx=4)
+        ttk.Button(bar, text="←", command=self._prev_bad_row).pack(side="left", padx=4)
+        ttk.Button(bar, text="→", command=self._next_bad_row).pack(side="left", padx=4)
+        ttk.Button(bar, text="OK", command=self._clip_ok).pack(side="left", padx=4)
+        ttk.Button(bar, text="mal", command=self._clip_bad).pack(side="left", padx=4)
+
+    # ---------------------------------------------------------------------------------
+    # navegación de archivos ----------------------------------------------------------
+    def _browse(self, var: tk.StringVar, ft: tuple[str, str]):
+        p = filedialog.askopenfilename(filetypes=[ft])
+        if p:
+            var.set(p)
+
+    # ------------------------------------------------------------------ utils
+    def clear_table(self) -> None:
+        self.tree.delete(*self.tree.get_children())
+        self.ok_rows.clear()
+
+    def save_json(self) -> None:
+        if not self.v_json.get():
+            p = filedialog.asksaveasfilename(
+                filetypes=[("QC JSON", "*.qc.json;*.json")],
+                defaultextension=".json",
+            )
+            if not p:
+                return
+            self.v_json.set(p)
+        try:
+            rows = [list(self.tree.item(i)["values"]) for i in self.tree.get_children()]
+            Path(self.v_json.get()).write_text(
+                json.dumps(rows, ensure_ascii=False, indent=2), encoding="utf8"
+            )
+            self._log(f"✔ Guardado {self.v_json.get()}")
+        except Exception as e:
+            messagebox.showerror("Error", str(e))
+
+    # ---------------------------------------------------------------------------------
+    # mensajes log ---------------------------------------------------------------------
+    def _log(self, msg: str):
+        self.log_box.configure(state="normal")
+        self.log_box.insert("end", msg + "\n")
+        self.log_box.configure(state="disabled")
+        self.log_box.see("end")
+
+    # ---------------------------------------------------------------------------------
+    # Transcripción -------------------------------------------------------------------
+    def transcribe(self):
+        if not self.v_audio.get():
+            messagebox.showwarning("Falta info", "Selecciona archivo de audio")
+            return
+        if not self.v_ref.get():
+            messagebox.showwarning(
+                "Falta info", "Selecciona guion para guiar la transcripción"
+            )
+            return
+        self._log("⏳ Transcribiendo…")
+        threading.Thread(target=self._transcribe_worker, daemon=True).start()
+
+    def _transcribe_worker(self) -> None:
+        try:
+            from transcriber import transcribe_file
+
+            out = transcribe_file(self.v_audio.get(), script_path=self.v_ref.get())
+            self.q.put(("SET_ASR", str(out)))
+            self.q.put(f"✔ Transcripción guardada en {out}")
+        except Exception:
+            buf = io.StringIO()
+            traceback.print_exc(file=buf)
+            err = buf.getvalue()
+            print(err)
+            self.q.put(err)
+
+    # ---------------------------------------------------------------------------------
+    # Procesar align ------------------------------------------------------------------
+    def launch(self):
+        if not (self.v_ref.get() and self.v_asr.get()):
+            messagebox.showwarning("Falta info", "Selecciona guion y TXT ASR.")
+            return
+        threading.Thread(target=self._worker, daemon=True).start()
+
+    # ---------------------------------------------------------------------------------
+    # AI review -----------------------------------------------------------------------
+    def ai_review(self):
+        if not self.v_json.get():
+            messagebox.showwarning("Falta info", "Cargar JSON primero")
+            return
+        if not os.getenv("OPENAI_API_KEY"):
+            messagebox.showwarning(
+                "Falta OPENAI_API_KEY",
+                "Configura la variable OPENAI_API_KEY antes de continuar",
+            )
+            return
+        if self.ai_one.get():
+            sel = self.tree.selection()
+            if not sel:
+                messagebox.showwarning("Falta info", "Selecciona una fila")
+                return
+            iid = sel[0]
+            original = self.tree.set(iid, "Original")
+            asr = self.tree.set(iid, "ASR")
+            self._log("⏳ Revisión AI fila…")
+            threading.Thread(
+                target=self._ai_review_one_worker,
+                args=(iid, original, asr),
+                daemon=True,
+            ).start()
+        else:
+            self._log(
+                "⏳ Solicitando revisión AI (esto puede tardar unos segundos)…"
+            )
+            threading.Thread(target=self._ai_review_worker, daemon=True).start()
+
+    def stop_ai_review(self):
+        try:
+            from ai_review import stop_review
+
+            stop_review()
+            self._log("⏹ Deteniendo análisis AI…")
+        except Exception as exc:
+            self._log(str(exc))
+
+    def _ai_review_worker(self) -> None:
+        try:
+            import ai_review
+
+            approved, remaining = ai_review.review_file(self.v_json.get())
+            self.q.put(("RELOAD", None))
+            if ai_review._stop_review:
+                self.q.put("⚠ Revisión detenida")
+            else:
+                self.q.put(f"✔ Auto-aprobadas {approved} / Restantes {remaining}")
+        except Exception:
+            buf = io.StringIO()
+            traceback.print_exc(file=buf)
+            err = buf.getvalue()
+            print(err)
+            self.q.put(err)
+
+    def _ai_review_one_worker(self, iid: str, original: str, asr: str) -> None:
+        try:
+            from ai_review import review_row
+
+            row = [0, "", "", 0.0, 0.0, original, asr]
+            review_row(row)
+            self.q.put(("AI_ROW", (iid, row[3], row[2])))
+        except Exception:
+            buf = io.StringIO()
+            traceback.print_exc(file=buf)
+            err = buf.getvalue()
+            print(err)
+            self.q.put(err)
+
+    # ------------------------------------------------------------------ reprocess
+    def reprocess_bad(self) -> None:
+        """Retranscribe rows marked as 'mal' without OK."""
+        if not self.v_audio.get():
+            messagebox.showwarning("Falta audio", "Selecciona archivo de audio")
+            return
+        for iid in self.tree.get_children():
+            ai = self.tree.set(iid, "AI").lower()
+            ok = self.tree.set(iid, "OK").lower()
+            if ai == "mal" and ok != "ok" and iid not in self.prev_asr:
+                self._retranscribe_row(iid)
+
+    def _retranscribe_row(self, iid: str) -> None:
+        """Transcribe a single row with Whisper large model."""
+        try:
+            from transcriber import transcribe_file
+        except Exception as exc:  # pragma: no cover - dependency missing
+            self._log(str(exc))
+            return
+
+        children = list(self.tree.get_children())
+        idx = children.index(iid)
+        start = 0.0
+        if idx > 0:
+            try:
+                start = float(self.tree.set(children[idx - 1], "tc"))
+            except Exception:
+                start = 0.0
+        try:
+            end = float(self.tree.set(children[idx + 1], "tc")) if idx + 1 < len(children) else None
+        except Exception:
+            end = None
+        if end is not None and end <= start:
+            end = None
+
+        clip_path = self._extract_clip(self.v_audio.get(), start, end)
+
+        words = self.tree.set(iid, "Original")
+        prompt = " ".join(sorted(set(words.split())))
+        tmp_prompt = Path(clip_path).with_suffix(".prompt.txt")
+        tmp_prompt.write_text(prompt, encoding="utf8")
+
+        out = transcribe_file(clip_path, model_size="large-v3", script_path=str(tmp_prompt))
+        new_text = Path(out).read_text(encoding="utf8").strip()
+        self.prev_asr[iid] = self.tree.set(iid, "ASR")
+        self.tree.set(iid, "ASR", new_text)
+        self.asr_confidence[iid] = 1.0  # placeholder
+
+        try:
+            os.remove(clip_path)
+            os.remove(tmp_prompt)
+        except OSError:
+            pass
+
+    def _extract_clip(self, path: str, start: float, end: float | None) -> str:
+        """Return temporary audio clip from start to end using ffmpeg."""
+        tmp = tempfile.NamedTemporaryFile(suffix=Path(path).suffix, delete=False)
+        tmp.close()
+        cmd = ["ffmpeg", "-y", "-i", path, "-ss", str(start)]
+        if end is not None:
+            cmd += ["-to", str(end)]
+        cmd += ["-c", "copy", tmp.name]
+        subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return tmp.name
+
+    # ---------------------------------------------------------------------------------
+    # JSON ---------------------------------------------------------------------------
+    def load_json(self):
+        if not self.v_json.get():
+            p = filedialog.askopenfilename(filetypes=[("QC JSON", "*.qc.json;*.json")])
+            if not p:
+                return
+            self.v_json.set(p)
+        try:
+            rows = json.loads(Path(self.v_json.get()).read_text(encoding="utf8"))
+            self.clear_table()
+            for r in rows:
+                if len(r) == 6:
+                    vals = [r[0], r[1], "", "", r[2], r[3], r[4], r[5]]
+                elif len(r) == 7:
+                    vals = [r[0], r[1], r[2], "", r[3], r[4], r[5], r[6]]
+                else:
+                    vals = r
+                vals[6], vals[7] = str(vals[6]), str(vals[7])
+                self.tree.insert("", tk.END, values=vals)
+            self._snapshot()
+            self._log(f"✔ Cargado {self.v_json.get()}")
+        except Exception as e:
+            messagebox.showerror("Error", str(e))
+
+    # ---------------------------------------------------------------------------------
+    # Reproducción -------------------------------------------------------------------
+    def _handle_double(self, event: tk.Event) -> None:
+        item = self.tree.identify_row(event.y)
+        col = self.tree.identify_column(event.x)
+        if not item:
+            return
+        if col == "#3":
+            self._toggle_ok(item)
+            return
+        self._play_clip(item)
+
+    def _play_clip(self, iid: str):
+        """Calcula tc inicio ‑ fin y prepara _clip_*"""
+        if not self.v_audio.get():
+            messagebox.showwarning("Falta audio", "Selecciona archivo de audio")
+            return
+        try:
+            start = float(self.tree.set(iid, "tc"))
+        except ValueError:
+            return
+        # siguiente
+        children = list(self.tree.get_children())
+        idx = children.index(iid)
+        end = None
+        if idx + 1 < len(children):
+            try:
+                end = float(self.tree.set(children[idx + 1], "tc"))
+            except ValueError:
+                pass
+        self._clip_item, self._clip_start, self._clip_end = iid, start, end
+        self._play_current_clip()
+
+    def _play_current_clip(self):
+        if self._clip_item and self.v_audio.get():
+            play_interval(self.v_audio.get(), self._clip_start, self._clip_end)
+
+    def _toggle_ok(self, item: str) -> None:
+        current = self.tree.set(item, "OK")
+        new_val = "" if current == "OK" else "OK"
+        self.tree.set(item, "OK", new_val)
+        try:
+            line_id = int(self.tree.set(item, "ID"))
+        except Exception:
+            return
+        if new_val:
+            self.ok_rows.add(line_id)
+        else:
+            self.ok_rows.discard(line_id)
+
+    def _clip_ok(self):
+        if self._clip_item:
+            self.tree.set(self._clip_item, "AI", "ok")
+        self._hide_clip()
+    def _clip_bad(self):
+        if self._clip_item:
+            self.tree.set(self._clip_item, "AI", "mal")
+        self._hide_clip()
+
+    def _toggle_asr(self) -> None:
+        """Swap between original and re‑transcribed ASR for selected row."""
+        if not self.selected_cell:
+            return
+        iid, col = self.selected_cell
+        if col != "#8":  # Only for ASR column
+            return
+        current = self.tree.set(iid, "ASR")
+        if iid in self.prev_asr:
+            self.tree.set(iid, "ASR", self.prev_asr[iid])
+            self.prev_asr[iid] = current
+
+    def _hide_clip(self) -> None:
+        try:
+            pygame.mixer.music.stop()
+        except Exception:
+            pass
+        self._clip_item = None
+
+    def _next_bad_row(self):
+        """Jump to the next row marked ``"mal"`` and not already ``"OK"``."""
+        children = list(self.tree.get_children())
+        if not children:
+            return
+        start = 0
+        if self._clip_item and self._clip_item in children:
+            start = children.index(self._clip_item) + 1
+        sequence = children[start:] + children[:start]
+        for iid in sequence:
+            if (
+                self.tree.set(iid, "AI") == "mal"
+                and self.tree.set(iid, "OK") != "OK"
+            ):
+                self.tree.see(iid)
+                self._play_clip(iid)
+                return
+
+    def _prev_bad_row(self):
+        """Jump to the previous row marked ``"mal"`` and not ``"OK"``."""
+        children = list(self.tree.get_children())
+        if not children:
+            return
+        start = len(children) - 1
+        if self._clip_item and self._clip_item in children:
+            start = children.index(self._clip_item) - 1
+        first_part = list(reversed(children[: start + 1]))
+        second_part = list(reversed(children[start + 1:]))
+        for iid in first_part + second_part:
+            if (
+                self.tree.set(iid, "AI") == "mal"
+                and self.tree.set(iid, "OK") != "OK"
+            ):
+                self.tree.see(iid)
+                self._play_clip(iid)
+                return
+
+    # --------------------------------------------------------------- cell utils
+    def _cell_click(self, event: tk.Event) -> None:
+        item = self.tree.identify_row(event.y)
+        col = self.tree.identify_column(event.x)
+        for iid in self.tree.get_children():
+            tags = list(self.tree.item(iid, "tags"))
+            if self.tree_tag in tags:
+                tags.remove(self.tree_tag)
+                self.tree.item(iid, tags=tuple(tags))
+        if col not in ("#7", "#8") or not item:
+            self.selected_cell = None
+            return
+        tags = list(self.tree.item(item, "tags"))
+        if self.tree_tag not in tags:
+            tags.append(self.tree_tag)
+            self.tree.item(item, tags=tuple(tags))
+        self.selected_cell = (item, col)
+
+    def _popup_menu(self, event: tk.Event) -> None:
+        item = self.tree.identify_row(event.y)
+        self._cell_click(event)
+        sel = self.tree.selection()
+        self.menu.entryconfig(
+            "Fusionar filas seleccionadas",
+            state="normal" if len(sel) > 1 else "disabled",
+        )
+        if item:
+            self.menu.tk_popup(event.x_root, event.y_root)
+
+    def _move_cell(self, direction: str) -> None:
+        if not self.selected_cell:
+            return
+        item, col_id = self.selected_cell
+        children = self.tree.get_children()
+        idx = children.index(item)
+        dst_idx = idx - 1 if direction == "up" else idx + 1
+        if dst_idx < 0 or dst_idx >= len(children):
+            return
+        dst_item = children[dst_idx]
+        col = "Original" if col_id == "#7" else "ASR"
+        src_text = self.tree.set(item, col)
+        if not src_text:
+            return
+        dst_text = self.tree.set(dst_item, col)
+        fused = (
+            (dst_text.rstrip().rstrip(".") + " " + src_text).strip()
+            if direction == "up"
+            else (src_text.rstrip(".") + " " + dst_text).strip()
+        )
+        self._snapshot()
+        self.tree.set(dst_item, col, fused)
+        self.tree.set(item, col, "")
+        other_col = "ASR" if col == "Original" else "Original"
+        if not self.tree.set(item, col) and not self.tree.set(item, other_col):
+            self.tree.delete(item)
+        self.selected_cell = None
+        for iid in self.tree.get_children():
+            tags = list(self.tree.item(iid, "tags"))
+            if self.tree_tag in tags:
+                tags.remove(self.tree_tag)
+                self.tree.item(iid, tags=tuple(tags))
+        self.save_json()
+
+    def _move_word(self, direction: str, which: str) -> None:
+        if not self.selected_cell:
+            return
+        item, col_id = self.selected_cell
+        children = self.tree.get_children()
+        idx = children.index(item)
+        dst_idx = idx - 1 if direction == "up" else idx + 1
+        if dst_idx < 0 or dst_idx >= len(children):
+            return
+        dst_item = children[dst_idx]
+        col = "Original" if col_id == "#7" else "ASR"
+        src_text = self.tree.set(item, col).strip()
+        if not src_text:
+            return
+        words = src_text.split()
+        if not words:
+            return
+        word = words.pop(0 if which == "first" else -1)
+        self._snapshot()
+        self.tree.set(item, col, " ".join(words))
+        dst_text = self.tree.set(dst_item, col).strip()
+        fused = (
+            (dst_text + " " + word).strip()
+            if direction == "up"
+            else (word + " " + dst_text).strip()
+        )
+        self.tree.set(dst_item, col, fused)
+        other_col = "ASR" if col == "Original" else "Original"
+        if not self.tree.set(item, col) and not self.tree.set(item, other_col):
+            self.tree.delete(item)
+        self.selected_cell = None
+        for iid in self.tree.get_children():
+            tags = list(self.tree.item(iid, "tags"))
+            if self.tree_tag in tags:
+                tags.remove(self.tree_tag)
+                self.tree.item(iid, tags=tuple(tags))
+        self.save_json()
+
+    def _merge_selected_rows(self) -> None:
+        sel = list(self.tree.selection())
+        if len(sel) < 2:
+            return
+        sel.sort(key=lambda iid: self.tree.index(iid))
+        first = sel[0]
+        originals: list[str] = []
+        asrs: list[str] = []
+
+        for iid in sel:
+            originals.append(self.tree.set(iid, "Original").strip())
+            asrs.append(self.tree.set(iid, "ASR").strip())
+
+        fuse = lambda parts: " ".join(p.rstrip(".,;") for p in parts if p)
+
+        self._snapshot()
+        self.merged_rows[first] = [list(self.tree.item(i)["values"]) for i in sel]
+
+        self.tree.set(first, "Original", fuse(originals))
+        self.tree.set(first, "ASR", fuse(asrs))
+        self.tree.set(first, "WER", "")
+
+        for iid in sel[1:]:
+            self.tree.delete(iid)
+            self.merged_rows.pop(iid, None)
+
+        tags = list(self.tree.item(first, "tags"))
+        if self.merged_tag not in tags:
+            tags.append(self.merged_tag)
+        self.tree.item(first, tags=tuple(tags))
+
+        start_idx = self.tree.index(first)
+        for new_id, iid in enumerate(self.tree.get_children()[start_idx:], start_idx):
+            self.tree.set(iid, "ID", new_id)
+
+        self.save_json()
+
+    def _unmerge_row(self) -> None:
+        sel = list(self.tree.selection())
+        if len(sel) != 1:
+            return
+        item = sel[0]
+        if item not in self.merged_rows:
+            return
+        rows = self.merged_rows.pop(item)
+        idx = self.tree.index(item)
+        self._snapshot()
+        self.tree.delete(item)
+        for r in rows:
+            iid = self.tree.insert("", idx, values=r)
+            idx += 1
+        for new_id, iid in enumerate(self.tree.get_children()):
+            self.tree.set(iid, "ID", new_id)
+        self.save_json()
+
+    # ---------------------------------------------------------------------------------
+    # hilo worker (alinear) -----------------------------------------------------------
+    def _worker(self):
+        try:
+            self.q.put("→ Leyendo guion…")
+            ref = read_script(self.v_ref.get())
+
+            self.q.put("→ TXT externo cargado")
+            hyp = Path(self.v_asr.get()).read_text(
+                encoding="utf8", errors="ignore"
+            )
+
+            self.q.put("→ Alineando…")
+            rows = build_rows(ref, hyp)
+
+            out = Path(self.v_asr.get()).with_suffix(".qc.json")
+            if out.exists():
+                try:
+                    old = json.loads(out.read_text(encoding="utf8"))
+                    from qc_utils import merge_qc_metadata
+
+                    rows = merge_qc_metadata(old, rows)
+                except Exception:
+                    pass
+            out.write_text(
+                json.dumps(rows, ensure_ascii=False, indent=2), encoding="utf8"
+            )
+
+            self.q.put(("ROWS", rows))
+            self.q.put(f"✔ Listo. Guardado en {out}")
+            self.v_json.set(str(out))
+        except Exception:
+            buf = io.StringIO()
+            traceback.print_exc(file=buf)
+            self.q.put(buf.getvalue())
+
+    # ---------------------------------------------------------------------------------
+    # cola de mensajes Tk -------------------------------------------------------------
+    def _poll(self):
+        try:
+            while True:
+                msg = self.q.get_nowait()
+                if isinstance(msg, tuple) and msg[0] == "ROWS":
+                    for r in msg[1]:
+                        if len(r) == 6:
+                            vals = [r[0], r[1], "", "", r[2], r[3], r[4], r[5]]
+                        else:
+                            vals = r
+                        vals[6], vals[7] = str(vals[6]), str(vals[7])
+                        self.tree.insert("", tk.END, values=vals)
+                    self._snapshot()
+                elif isinstance(msg, tuple) and msg[0] == "RELOAD":
+                    self.load_json()
+                elif isinstance(msg, tuple) and msg[0] == "SET_ASR":
+                    self.v_asr.set(msg[1])
+                elif isinstance(msg, tuple) and msg[0] == "AI_ROW":
+                    iid, verdict, ok = msg[1]
+                    self.tree.set(iid, "AI", verdict)
+                    if ok:
+                        self.tree.set(iid, "OK", ok)
+                        try:
+                            line_id = int(self.tree.set(iid, "ID"))
+                            self.ok_rows.add(line_id)
+                        except Exception:
+                            pass
+                    self.save_json()
+                else:
+                    self._log(str(msg))
+        except queue.Empty:
+            pass
+        self.after(250, self._poll)
+
+    # ------------------------------------------------------------- undo/redo --
+    def _snapshot(self) -> None:
+        rows = [list(self.tree.item(i)["values"]) for i in self.tree.get_children()]
+        self.undo_stack.append(json.dumps(rows, ensure_ascii=False))
+        if len(self.undo_stack) > 20:
+            self.undo_stack.pop(0)
+        self.redo_stack.clear()
+
+    def _restore(self, data: str) -> None:
+        rows = json.loads(data)
+        self.clear_table()
+        for r in rows:
+            if len(r) == 6:
+                vals = [r[0], r[1], "", "", r[2], r[3], r[4], r[5]]
+            elif len(r) == 7:
+                vals = [r[0], r[1], r[2], "", r[3], r[4], r[5], r[6]]
+            else:
+                vals = r
+            vals[6], vals[7] = str(vals[6]), str(vals[7])
+            self.tree.insert("", tk.END, values=vals)
+
+    def undo(self, event: tk.Event | None = None) -> None:
+        if not self.undo_stack:
+            return
+        state = self.undo_stack.pop()
+        current = json.dumps([
+            list(self.tree.item(i)["values"]) for i in self.tree.get_children()
+        ], ensure_ascii=False)
+        self.redo_stack.append(current)
+        self._restore(state)
+        self.save_json()
+
+    def redo(self, event: tk.Event | None = None) -> None:
+        if not self.redo_stack:
+            return
+        state = self.redo_stack.pop()
+        current = json.dumps([
+            list(self.tree.item(i)["values"]) for i in self.tree.get_children()
+        ], ensure_ascii=False)
+        self.undo_stack.append(current)
+        self._restore(state)
+        self.save_json()
+
+# --------------------------------------------------------------------------------------
+if __name__ == "__main__":
+    App().mainloop()


### PR DESCRIPTION
## Summary
- create `qc_app_adv.py` with features to retranscribe rows marked as `mal`
- store original ASR text and toggle between versions
- add button and context menu action for retranscription workflow

## Testing
- `flake8 qc_app_adv.py | head`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867fc8d10b0832aa03d512e1373d4ed