### PR TITLE
Improve GUI error reporting

### DIFF
--- a/qc_app.py
+++ b/qc_app.py
@@ -21,6 +21,8 @@ import pygame
 import tkinter as tk
 from tkinter import filedialog, messagebox, scrolledtext, ttk
 
+from utils.gui_errors import show_error
+
 from alignment import build_rows
 from text_utils import read_script
 
@@ -212,7 +214,7 @@ class App(tk.Tk):
             )
             self._log(f"✔ Guardado {self.v_json.get()}")
         except Exception as e:
-            messagebox.showerror("Error", str(e))
+            show_error("Error", e)
 
     # ---------------------------------------------------------------------------------
     # mensajes log ---------------------------------------------------------------------
@@ -243,12 +245,8 @@ class App(tk.Tk):
             out = transcribe_file(self.v_audio.get(), script_path=self.v_ref.get())
             self.q.put(("SET_ASR", str(out)))
             self.q.put(f"✔ Transcripción guardada en {out}")
-        except Exception:
-            buf = io.StringIO()
-            traceback.print_exc(file=buf)
-            err = buf.getvalue()
-            print(err)
-            self.q.put(err)
+        except BaseException as exc:  # noqa: BLE001 - catch SystemExit too
+            show_error("Error", exc)
 
     # ---------------------------------------------------------------------------------
     # Procesar align ------------------------------------------------------------------
@@ -353,7 +351,7 @@ class App(tk.Tk):
             self._snapshot()
             self._log(f"✔ Cargado {self.v_json.get()}")
         except Exception as e:
-            messagebox.showerror("Error", str(e))
+            show_error("Error", e)
 
     # ---------------------------------------------------------------------------------
     # Reproducción -------------------------------------------------------------------

--- a/qc_app_adv.py
+++ b/qc_app_adv.py
@@ -23,6 +23,8 @@ import pygame
 import tkinter as tk
 from tkinter import filedialog, messagebox, scrolledtext, ttk
 
+from utils.gui_errors import show_error
+
 from alignment import build_rows
 from text_utils import read_script
 
@@ -220,7 +222,7 @@ class App(tk.Tk):
             )
             self._log(f"✔ Guardado {self.v_json.get()}")
         except Exception as e:
-            messagebox.showerror("Error", str(e))
+            show_error("Error", e)
 
     # ---------------------------------------------------------------------------------
     # mensajes log ---------------------------------------------------------------------
@@ -251,12 +253,8 @@ class App(tk.Tk):
             out = transcribe_file(self.v_audio.get(), script_path=self.v_ref.get())
             self.q.put(("SET_ASR", str(out)))
             self.q.put(f"✔ Transcripción guardada en {out}")
-        except Exception:
-            buf = io.StringIO()
-            traceback.print_exc(file=buf)
-            err = buf.getvalue()
-            print(err)
-            self.q.put(err)
+        except BaseException as exc:  # noqa: BLE001 - catch SystemExit too
+            show_error("Error", exc)
 
     # ---------------------------------------------------------------------------------
     # Procesar align ------------------------------------------------------------------
@@ -426,7 +424,7 @@ class App(tk.Tk):
             self._snapshot()
             self._log(f"✔ Cargado {self.v_json.get()}")
         except Exception as e:
-            messagebox.showerror("Error", str(e))
+            show_error("Error", e)
 
     # ---------------------------------------------------------------------------------
     # Reproducción -------------------------------------------------------------------

--- a/tests/test_gui_errors.py
+++ b/tests/test_gui_errors.py
@@ -1,0 +1,20 @@
+import io
+import sys
+from utils.gui_errors import show_error
+import tkinter.messagebox as messagebox
+
+
+def test_show_error_logs_and_dialog(monkeypatch):
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", buf)
+    called = {}
+    def fake_showerror(title, msg):
+        called["title"] = title
+        called["msg"] = msg
+    monkeypatch.setattr(messagebox, "showerror", fake_showerror)
+    exc = RuntimeError("boom")
+    show_error("Oops", exc)
+    assert called["title"] == "Oops"
+    assert called["msg"] == "boom"
+    out = buf.getvalue()
+    assert "RuntimeError" in out and "boom" in out

--- a/tests/test_transcribe_worker_error.py
+++ b/tests/test_transcribe_worker_error.py
@@ -1,0 +1,32 @@
+import os
+import importlib
+import pytest
+
+sys_path = os.path.dirname(os.path.dirname(__file__))
+import sys
+sys.path.insert(0, sys_path)
+
+modules = ["qc_app", "qc_app_adv"]
+
+if not os.environ.get("DISPLAY"):
+    pytest.skip("no display", allow_module_level=True)
+
+
+@pytest.mark.parametrize("mod_name", modules)
+def test_transcribe_worker_systemexit(monkeypatch, mod_name):
+    mod = importlib.import_module(mod_name)
+    app = mod.App()
+    try:
+        def fake_transcribe_file(*a, **k):
+            raise SystemExit("fail")
+        monkeypatch.setattr("transcriber.transcribe_file", fake_transcribe_file)
+        called = {}
+        def fake_show_error(title, exc):
+            called["msg"] = str(exc)
+        monkeypatch.setattr(mod, "show_error", fake_show_error)
+        app.v_audio.set("x")
+        app.v_ref.set("y")
+        app._transcribe_worker()
+        assert "fail" in called["msg"]
+    finally:
+        app.destroy()

--- a/utils/gui_errors.py
+++ b/utils/gui_errors.py
@@ -1,0 +1,9 @@
+import sys
+import traceback
+from tkinter import messagebox
+
+
+def show_error(title: str, exc: BaseException) -> None:
+    """Show a Tk error dialog and log full traceback to stderr."""
+    traceback.print_exception(type(exc), exc, exc.__traceback__, file=sys.stderr)
+    messagebox.showerror(title, str(exc))

--- a/utils/resync_json.py
+++ b/utils/resync_json.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import json, re, sys, threading, tkinter as tk
 from pathlib import Path
 from tkinter import filedialog, scrolledtext, ttk, messagebox
+
+from utils.gui_errors import show_error
 from typing import List, Tuple
 
 ###########################################################################
@@ -135,7 +137,7 @@ class ResyncApp(tk.Tk):
     def launch(self):
         pj, pc = self.v_json.get(), self.v_csv.get()
         if not (pj and pc):
-            messagebox.showerror("Falta info", "Selecciona JSON y CSV")
+            show_error("Falta info", ValueError("Selecciona JSON y CSV"))
             return
         threading.Thread(target=self.worker, args=(Path(pj), Path(pc)), daemon=True).start()
 
@@ -149,7 +151,7 @@ class ResyncApp(tk.Tk):
             self.log_msg("Leyendo CSV word‑timings…")
             words, starts = load_words_csv(csv_path)
             if not words:
-                messagebox.showerror("Error", "CSV no contiene datos utilizables")
+                show_error("Error", ValueError("CSV no contiene datos utilizables"))
                 return
             self.log_msg(f"→ {len(words)} palabras cargadas")
 

--- a/utils/resync_python_v2.py
+++ b/utils/resync_python_v2.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import json, re, sys, threading, tkinter as tk
 from pathlib import Path
 from tkinter import filedialog, scrolledtext, ttk, messagebox
+
+from utils.gui_errors import show_error
 from typing import List, Tuple
 import unicodedata
 from difflib import SequenceMatcher
@@ -209,7 +211,7 @@ class ResyncApp(tk.Tk):
     def launch(self):
         pj,pc=self.v_json.get(),self.v_csv.get()
         if not (pj and pc):
-            messagebox.showerror("Falta info","Selecciona JSON y CSV"); return
+            show_error("Falta info", ValueError("Selecciona JSON y CSV")); return
         threading.Thread(target=self.worker,args=(Path(pj),Path(pc)),daemon=True).start()
 
     def worker(self,json_path:Path,csv_path:Path):
@@ -219,7 +221,7 @@ class ResyncApp(tk.Tk):
 
             self.log_msg("Leyendo CSV word-timings…")
             csv_words,csv_tcs=load_words_csv(csv_path)
-            if not csv_words: messagebox.showerror("Error","CSV vacío"); return
+            if not csv_words: show_error("Error", ValueError("CSV vacío")); return
             self.log_msg(f"→ {len(csv_words)} palabras en CSV")
 
             resync_rows(rows,csv_words,csv_tcs,

--- a/utils/word_timed_transcriber.py
+++ b/utils/word_timed_transcriber.py
@@ -36,6 +36,7 @@ USE_GUI = not (sys.platform.startswith("linux") and not os.environ.get("DISPLAY"
 if USE_GUI:
     import tkinter as tk
     from tkinter import ttk, filedialog, messagebox, scrolledtext
+    from utils.gui_errors import show_error
 
 # ---------------------------------------------------------------------------
 # Helpers ────────────────────────────────────────────────────────────────────
@@ -213,7 +214,7 @@ if USE_GUI:
                 messagebox.showwarning("Falta archivo", "Selecciona audio primero")
                 return
             if self.v_test.get() and not have_ffmpeg():
-                messagebox.showerror("FFmpeg faltante", "El modo prueba necesita FFmpeg en PATH")
+                show_error("FFmpeg faltante", RuntimeError("El modo prueba necesita FFmpeg en PATH"))
                 return
             self.pb["value"] = 0
             self.eta_lbl["text"] = ""

--- a/utils/word_timed_transcriber_2.py
+++ b/utils/word_timed_transcriber_2.py
@@ -124,6 +124,7 @@ USE_GUI = not (sys.platform.startswith("linux") and not os.environ.get("DISPLAY"
 if USE_GUI:
     import tkinter as tk
     from tkinter import filedialog, messagebox, scrolledtext, ttk
+    from utils.gui_errors import show_error
 
     class App(tk.Tk):
         def __init__(self):
@@ -176,7 +177,7 @@ if USE_GUI:
                 messagebox.showwarning("Falta archivo", "Selecciona audio")
                 return
             if self.v_test.get() and not have_ffmpeg():
-                messagebox.showerror("FFmpeg requerido", "Instala FFmpeg o desactiva modo prueba")
+                show_error("FFmpeg requerido", RuntimeError("Instala FFmpeg o desactiva modo prueba"))
                 return
 
             self.pb["value"] = 0


### PR DESCRIPTION
## Summary
- add utility `utils/gui_errors.py` to display Tk error dialogs and log traceback
- use `show_error` in both QC apps and helper utilities
- catch `SystemExit` in transcription workers
- test `show_error` and transcription worker errors

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686801951970832aa4548c9502db3075