### PR TITLE
Enhance re‑transcription and AI scoring

### DIFF
--- a/transcriber.py
+++ b/transcriber.py
@@ -165,6 +165,8 @@ def transcribe_file(
     file_path: str | None = None,
     model_size: str | None = None,
     script_path: str | None = None,
+    *,
+    show_messagebox: bool = True,
 ) -> Path:
     """Transcribe ``file_path`` with Whisper and save ``.txt`` next to it.
 
@@ -213,7 +215,7 @@ def transcribe_file(
         except OSError:
             pass
 
-    if tk is not None:
+    if tk is not None and show_messagebox:
         messagebox.showinfo(
             title="Transcripción finalizada", message=f"Guardado en:\n{out_path}"
         )


### PR DESCRIPTION
## Summary
- allow disabling the completion popup in `transcribe_file`
- add re-review scoring utilities in `ai_review`
- re-transcribe rows without blocking message boxes and auto score each row

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bb47bd8d8832a996ddf61a3ee7e3e