### PR TITLE
Implement pause for retranscription and scoring column

### DIFF
--- a/qc_utils.py
+++ b/qc_utils.py
@@ -24,7 +24,7 @@ def merge_qc_metadata(old_rows: List[List], new_rows: List[List]) -> List[List]:
     old_norm = [normalize(str(r[-2])) for r in old_rows]
 
     for new in new_rows:
-        base = [new[0], new[1], "", "", new[2], new[3], new[4], new[5]]
+        base = [new[0], new[1], "", "", "", new[2], new[3], new[4], new[5]]
         n_norm = normalize(str(new[-2]))
         best = None
         best_sim = 0.8
@@ -40,7 +40,9 @@ def merge_qc_metadata(old_rows: List[List], new_rows: List[List]) -> List[List]:
                 base[2] = best[2]
             if len(best) > 3:
                 base[3] = best[3]
-            if len(best) > 8:
-                base.extend(best[8:])
+            if len(best) > 4:
+                base[4] = best[4]
+            if len(best) > 9:
+                base.extend(best[9:])
         merged.append(base)
     return merged


### PR DESCRIPTION
## Summary
- allow retranscription process to be paused
- highlight rows while retranscribing
- show AI re-review score in new `Score` column and auto-mark as ok
- keep compatibility when loading older JSON files

## Testing
- `flake8` *(fails: F401, E302, E221, etc.)*
- `pytest -q` *(fails: ModuleNotFoundError: httpx, rapidfuzz, pygame, unidecode)*

------
https://chatgpt.com/codex/tasks/task_e_686bc92e8a7c832a90605e904fc14842