### PR TITLE
Update retranscription prompt

### DIFF
--- a/ai_review.py
+++ b/ai_review.py
@@ -140,6 +140,15 @@ REREVIEW_PROMPT = (
     + "\n\nAfter your assessment respond ONLY with a single number from 1 to 5 "
     + "where 1 means mal and 5 means ok."
 )
+
+# Prompt used when re-transcribing problematic lines. The ASR text may include
+# one or more extra lines for context. The model must evaluate **only the first
+# line** against the provided ORIGINAL text.
+RETRANS_PROMPT = (
+    DEFAULT_PROMPT
+    + "\n\nThe ASR text may include extra lines for context. "
+    + "Judge ONLY the first line against the ORIGINAL text."
+)
 # This is a testing phase: if you respond "mal" or "dudoso", provide a brief
 # explanation of the specific reason for your assessment.
 # Respond clearly with one of these words: ok, mal, or dudoso, followed by a

--- a/qc_app_adv.py
+++ b/qc_app_adv.py
@@ -427,11 +427,11 @@ class App(tk.Tk):
 
         # AI re-review using new transcription
         try:
-            from ai_review import review_row, score_row
+            from ai_review import review_row, score_row, RETRANS_PROMPT
 
             row = [0, "", "", 0.0, 0.0, words, new_text]
-            review_row(row)
-            rating = score_row(row)
+            review_row(row, RETRANS_PROMPT)
+            rating = score_row(row, RETRANS_PROMPT)
             self.tree.set(iid, "Score", rating)
             if float(rating) >= 4:
                 self.tree.set(iid, "AI", "ok")

--- a/tests/test_qc_app_adv.py
+++ b/tests/test_qc_app_adv.py
@@ -1,0 +1,60 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from qc_app_adv import App  # noqa: E402
+import ai_review  # noqa: E402
+
+
+if not os.environ.get("DISPLAY"):
+    pytest.skip("no display", allow_module_level=True)
+
+
+def test_retranscribe_row_uses_custom_prompt(tmp_path, monkeypatch):
+    app = App()
+    try:
+        # Prepare dummy audio path and row
+        audio = tmp_path / "a.wav"
+        audio.write_text("dummy")
+        app.v_audio.set(str(audio))
+        iid = app.tree.insert("", "end", values=[0, "", "", "", "", "", "0.0", "hola", "halo"])
+
+        # Mock internal helpers
+        clip = tmp_path / "clip.wav"
+        clip.write_text("audio")
+        monkeypatch.setattr(app, "_extract_clip", lambda *a, **k: str(clip))
+
+        out_file = tmp_path / "out.txt"
+
+        def fake_transcribe(*a, **k):
+            out_file.write_text("nuevo")
+            return str(out_file)
+
+        monkeypatch.setattr("transcriber.transcribe_file", fake_transcribe)
+
+        review_args = {}
+        score_args = {}
+
+        def fake_review(row, prompt=None):
+            review_args["prompt"] = prompt
+            row[2] = "OK"
+            row.insert(3, "ok")
+            return "ok"
+
+        def fake_score(row, prompt=None):
+            score_args["prompt"] = prompt
+            return "5"
+
+        monkeypatch.setattr("ai_review.review_row", fake_review)
+        monkeypatch.setattr("ai_review.score_row", fake_score)
+        monkeypatch.setattr(app, "save_json", lambda: None)
+
+        app._retranscribe_row(iid)
+
+        assert review_args["prompt"] == ai_review.RETRANS_PROMPT
+        assert score_args["prompt"] == ai_review.RETRANS_PROMPT
+    finally:
+        app.destroy()
+


### PR DESCRIPTION
## Summary
- refine ai review prompts
- call new RETRANS_PROMPT when re-transcribing in `qc_app_adv`
- test that `_retranscribe_row` uses the custom prompt

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_686be18fe000832a95f40660ff1c8b2d