### PR TITLE
Fix merge metadata column order

### DIFF
--- a/qc_utils.py
+++ b/qc_utils.py
@@ -23,8 +23,23 @@ def merge_qc_metadata(old_rows: List[List], new_rows: List[List]) -> List[List]:
 
     old_norm = [normalize(str(r[-2])) for r in old_rows]
 
+    has_score = any(len(r) >= 9 for r in old_rows)
+
     for new in new_rows:
-        base = [new[0], new[1], "", "", "", new[2], new[3], new[4], new[5]]
+        if has_score:
+            base = [
+                new[0],
+                new[1],
+                "",
+                "",
+                "",
+                new[2],
+                new[3],
+                new[4],
+                new[5],
+            ]
+        else:
+            base = [new[0], new[1], "", "", new[2], new[3], new[4], new[5]]
         n_norm = normalize(str(new[-2]))
         best = None
         best_sim = 0.8
@@ -40,9 +55,10 @@ def merge_qc_metadata(old_rows: List[List], new_rows: List[List]) -> List[List]:
                 base[2] = best[2]
             if len(best) > 3:
                 base[3] = best[3]
-            if len(best) > 4:
+            if has_score and len(best) > 4:
                 base[4] = best[4]
-            if len(best) > 9:
-                base.extend(best[9:])
+            extra_idx = 9 if has_score else 8
+            if len(best) > extra_idx:
+                base.extend(best[extra_idx:])
         merged.append(base)
     return merged

--- a/tests/test_qc_utils.py
+++ b/tests/test_qc_utils.py
@@ -5,6 +5,7 @@ def test_merge_qc_metadata_transfers_fields():
     old = [[0, "✅", "OK", "mal", 10.0, 0.5, "hola amigos", "hola amigos"]]
     new = [[0, "❌", 20.0, 1.0, "hola amigo", "hola amigo"]]
     merged = qc_utils.merge_qc_metadata(old, new)
+    assert len(merged[0]) == 8
     assert merged[0][1] == "✅"
     assert merged[0][2] == "OK"
     assert merged[0][3] == "mal"
@@ -15,6 +16,16 @@ def test_merge_qc_metadata_when_different():
     old = [[0, "✅", "OK", "mal", 10.0, 0.5, "hola", "hola"]]
     new = [[0, "❌", 20.0, 1.0, "adios mundo", "adios mundo"]]
     merged = qc_utils.merge_qc_metadata(old, new)
+    assert len(merged[0]) == 8
     assert merged[0][1] == "❌"
     assert merged[0][2] == ""
     assert merged[0][3] == ""
+
+
+def test_merge_qc_metadata_preserves_score_column():
+    old = [[0, "✅", "OK", "mal", "4", 10.0, 0.5, "hola", "hola"]]
+    new = [[0, "❌", 20.0, 1.0, "hola", "hola"]]
+    merged = qc_utils.merge_qc_metadata(old, new)
+    assert len(merged[0]) == 9
+    assert merged[0][4] == "4"
+    assert merged[0][5] == 20.0


### PR DESCRIPTION
## Summary
- ensure `merge_qc_metadata` keeps 8 columns unless old rows include a score column
- test row length handling with and without the score field

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e67f40084832a84f1cb59b7c9f880