### PR TITLE
Integrate word timed transcription option

### DIFF
--- a/qc_app.py
+++ b/qc_app.py
@@ -57,6 +57,7 @@ class App(tk.Tk):
         self.v_audio = tk.StringVar(self)
         self.v_json  = tk.StringVar(self)
         self.ai_one  = tk.BooleanVar(self, value=False)
+        self.use_wordcsv = tk.BooleanVar(self, value=False)
 
         # Estados internos
         self.q:   queue.Queue = queue.Queue()
@@ -91,6 +92,7 @@ class App(tk.Tk):
                         ("Media", "*.mp3;*.wav;*.m4a;*.flac;*.ogg;*.aac;*.mp4"))
 
         ttk.Button(top, text="Transcribir", command=self.transcribe).grid(row=2, column=3, padx=6)
+        ttk.Checkbutton(top, text="CSV palabras", variable=self.use_wordcsv).grid(row=2, column=4, padx=4)
         ttk.Button(top, text="Procesar", width=11, command=self.launch).grid(row=0, column=3, rowspan=2, padx=6)
 
         ttk.Label(top, text="JSON:").grid(row=3, column=0, sticky="e")
@@ -242,9 +244,12 @@ class App(tk.Tk):
 
     def _transcribe_worker(self) -> None:
         try:
-            from transcriber import transcribe_file
+            from transcriber import transcribe_file, transcribe_word_csv
 
-            out = transcribe_file(self.v_audio.get(), script_path=self.v_ref.get())
+            if self.use_wordcsv.get():
+                out = transcribe_word_csv(self.v_audio.get())
+            else:
+                out = transcribe_file(self.v_audio.get(), script_path=self.v_ref.get())
             self.q.put(("SET_ASR", str(out)))
             self.q.put(f"✔ Transcripción guardada en {out}")
         except BaseException as exc:  # noqa: BLE001 - catch SystemExit too
@@ -689,6 +694,14 @@ class App(tk.Tk):
 
             self.q.put("→ Alineando…")
             rows = build_rows(ref, hyp)
+            if self.use_wordcsv.get():
+                try:
+                    from utils.resync_python_v2 import load_words_csv, resync_rows
+                    csv_path = Path(self.v_audio.get()).with_suffix(".words.csv")
+                    csv_words, csv_tcs = load_words_csv(csv_path)
+                    resync_rows(rows, csv_words, csv_tcs)
+                except Exception as exc:
+                    self.q.put(f"Resync error: {exc}")
 
             # ═══ DEBUG TEMPORAL ═══
             self.q.put(f"→ DEBUG: Se generaron {len(rows)} filas")

--- a/qc_app_adv.py
+++ b/qc_app_adv.py
@@ -59,6 +59,7 @@ class App(tk.Tk):
         self.v_audio = tk.StringVar(self)
         self.v_json  = tk.StringVar(self)
         self.ai_one  = tk.BooleanVar(self, value=False)
+        self.use_wordcsv = tk.BooleanVar(self, value=False)
 
         # Estados internos
         self.q:   queue.Queue = queue.Queue()
@@ -98,6 +99,7 @@ class App(tk.Tk):
                         ("Media", "*.mp3;*.wav;*.m4a;*.flac;*.ogg;*.aac;*.mp4"))
 
         ttk.Button(top, text="Transcribir", command=self.transcribe).grid(row=2, column=3, padx=6)
+        ttk.Checkbutton(top, text="CSV palabras", variable=self.use_wordcsv).grid(row=2, column=6, padx=4)
         ttk.Button(top, text="Procesar", width=11, command=self.launch).grid(row=0, column=3, rowspan=2, padx=6)
 
         ttk.Label(top, text="JSON:").grid(row=3, column=0, sticky="e")
@@ -254,9 +256,12 @@ class App(tk.Tk):
 
     def _transcribe_worker(self) -> None:
         try:
-            from transcriber import transcribe_file
+            from transcriber import transcribe_file, transcribe_word_csv
 
-            out = transcribe_file(self.v_audio.get(), script_path=self.v_ref.get())
+            if self.use_wordcsv.get():
+                out = transcribe_word_csv(self.v_audio.get())
+            else:
+                out = transcribe_file(self.v_audio.get(), script_path=self.v_ref.get())
             self.q.put(("SET_ASR", str(out)))
             self.q.put(f"✔ Transcripción guardada en {out}")
         except BaseException as exc:  # noqa: BLE001 - catch SystemExit too
@@ -781,6 +786,14 @@ class App(tk.Tk):
 
             self.q.put("→ Alineando…")
             rows = build_rows(ref, hyp)
+            if self.use_wordcsv.get():
+                try:
+                    from utils.resync_python_v2 import load_words_csv, resync_rows
+                    csv_path = Path(self.v_audio.get()).with_suffix(".words.csv")
+                    csv_words, csv_tcs = load_words_csv(csv_path)
+                    resync_rows(rows, csv_words, csv_tcs)
+                except Exception as exc:
+                    self.q.put(f"Resync error: {exc}")
 
             out = Path(self.v_asr.get()).with_suffix(".qc.json")
             if out.exists():

--- a/utils/resync_python_v2.py
+++ b/utils/resync_python_v2.py
@@ -168,13 +168,22 @@ def resync_rows(rows: List[List], csv_words: List[str], csv_tcs: List[float],
             last_tc=row_tc[i]
 
     # h) escribir tc en la columna adecuada  / progress
-    tc_idx = {6: 3, 7: 4, 8: 5}.get(len(rows[0]), len(rows[0]) - 1)
+    tc_idx = 5 if len(rows[0]) > 5 else len(rows[0])
     for i, row in enumerate(rows):
         if len(row) <= tc_idx:
             row.extend([""] * (tc_idx - len(row) + 1))
         row[tc_idx] = f"{row_tc[i]:.2f}"
         if i % 10 == 0:
             progress_cb(i / len(rows))
+
+
+def resync_file(json_path: str | Path, csv_path: str | Path) -> List[List]:
+    """Return rows from ``json_path`` with updated ``tc`` using ``csv_path``."""
+
+    rows = json.loads(Path(json_path).read_text(encoding="utf8"))
+    csv_words, csv_tcs = load_words_csv(Path(csv_path))
+    resync_rows(rows, csv_words, csv_tcs)
+    return rows
 
 ###########################################################################################
 # ▸ 6. GUI  (sin cambios visuales)


### PR DESCRIPTION
## Summary
- add `transcribe_word_csv` using `word_timed_transcriber_2`
- enable `--word-align-v2` CLI using new resync implementation
- update Tk apps with optional CSV timed transcription
- expose `resync_file` helper in `resync_python_v2`

## Testing
- `flake8` *(fails: many style violations)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882379dd2e8832a85632e9465159d65