### PR TITLE
Normalize QC row order

### DIFF
--- a/qc_app.py
+++ b/qc_app.py
@@ -277,15 +277,9 @@ class App(tk.Tk):
         Retorna siempre 8-columnas en el orden que usa la GUI.
         """
 
-        if len(r) == 6:
-            #           ID  ✓   OK AI WER  tc  Original  ASR
-            return [r[0], r[1], "", "", r[2], r[3], r[4], r[5]]
+        from qc_utils import canonical_row
 
-        if len(r) == 7:
-            #           ID  ✓   OK  AI WER  tc  Original  ASR
-            return [r[0], r[1], r[2], "", r[3], r[4], r[5], r[6]]
-
-        return r  # ya vienen 8 columnas
+        return canonical_row(r)
 
     # ───────────────────────────────── ventana de progreso ─────────────────────────
     def _show_progress(self, text: str = "Procesando…", *, determinate: bool = False) -> None:

--- a/qc_app_adv.py
+++ b/qc_app_adv.py
@@ -485,16 +485,13 @@ class App(tk.Tk):
         try:
             rows = json.loads(Path(self.v_json.get()).read_text(encoding="utf8"))
             self.clear_table()
+            from qc_utils import canonical_row
+
             for r in rows:
-                if len(r) == 6:
-                    vals = [r[0], r[1], "", "", "", r[2], r[3], r[4], r[5]]
-                elif len(r) == 7:
-                    vals = [r[0], r[1], r[2], "", "", r[3], r[4], r[5], r[6]]
-                elif len(r) == 8:
-                    vals = [r[0], r[1], r[2], r[3], "", r[4], r[5], r[6], r[7]]
-                else:
-                    vals = r
+                vals = canonical_row(r)
                 vals[-2], vals[-1] = str(vals[-2]), str(vals[-1])
+                if len(vals) < 9:
+                    vals.insert(4, "")  # ensure Score column exists
                 self.tree.insert("", tk.END, values=vals)
             self._snapshot()
             self._log(f"✔ Cargado {self.v_json.get()}")

--- a/qc_utils.py
+++ b/qc_utils.py
@@ -62,3 +62,25 @@ def merge_qc_metadata(old_rows: List[List], new_rows: List[List]) -> List[List]:
                 base.extend(best[extra_idx:])
         merged.append(base)
     return merged
+
+
+
+def canonical_row(row: List) -> List:
+    """Return row in standard QC order.
+
+    The canonical format is either ``[ID, ✓, OK, AI, WER, tc, Original, ASR]``
+    or ``[ID, ✓, OK, AI, Score, WER, tc, Original, ASR]`` when a Score column is
+    present. Input rows may omit some of these columns. Missing fields are filled
+    with empty strings so that the output always has either 8 or 9 elements.
+    """
+    if len(row) >= 9:
+        return row[:9]
+    if len(row) == 8:
+        return row
+    if len(row) == 7:
+        # [ID, ✓, OK, WER, tc, Original, ASR]
+        return [row[0], row[1], row[2], "", row[3], row[4], row[5], row[6]]
+    if len(row) == 6:
+        # [ID, ✓, WER, tc, Original, ASR]
+        return [row[0], row[1], "", "", row[2], row[3], row[4], row[5]]
+    return row

--- a/tests/test_qc_utils.py
+++ b/tests/test_qc_utils.py
@@ -29,3 +29,15 @@ def test_merge_qc_metadata_preserves_score_column():
     assert len(merged[0]) == 9
     assert merged[0][4] == "4"
     assert merged[0][5] == 20.0
+
+
+def test_canonical_row_variants():
+    six = [0, "✅", 10.0, 0.5, "hola", "hola"]
+    seven = [0, "✅", "OK", 10.0, 0.5, "hola", "hola"]
+    eight = [0, "✅", "OK", "mal", 10.0, 0.5, "hola", "hola"]
+    nine = [0, "✅", "OK", "mal", "4", 10.0, 0.5, "hola", "hola"]
+
+    assert qc_utils.canonical_row(six) == [0, "✅", "", "", 10.0, 0.5, "hola", "hola"]
+    assert qc_utils.canonical_row(seven) == [0, "✅", "OK", "", 10.0, 0.5, "hola", "hola"]
+    assert qc_utils.canonical_row(eight) == eight
+    assert qc_utils.canonical_row(nine) == nine


### PR DESCRIPTION
## Summary
- add `canonical_row` utility for consistent QC column order
- use `canonical_row` in GUI loaders
- test `canonical_row` coverage

## Testing
- `pytest -q`
- `flake8` *(fails: E302, F401, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6882426a37f0832ab778e55ae6214dea