### PR TITLE
Fix resync to preserve ASR

### DIFF
--- a/qc_app.py
+++ b/qc_app.py
@@ -25,6 +25,7 @@ from utils.gui_errors import show_error
 
 from alignment import build_rows
 from text_utils import read_script
+from qc_utils import canonical_row
 
 # --------------------------------------------------------------------------------------
 # utilidades de audio ------------------------------------------------------------------
@@ -712,7 +713,7 @@ class App(tk.Tk):
             # ═══ FIN DEBUG ═══
 
             self.q.put("→ Alineando…")
-            rows = build_rows(ref, hyp)
+            rows = [canonical_row(r) for r in build_rows(ref, hyp)]
             if self.use_wordcsv.get():
                 try:
                     from utils.resync_python_v2 import load_words_csv, resync_rows

--- a/qc_app_adv.py
+++ b/qc_app_adv.py
@@ -27,6 +27,7 @@ from utils.gui_errors import show_error
 
 from alignment import build_rows
 from text_utils import read_script
+from qc_utils import canonical_row
 
 # --------------------------------------------------------------------------------------
 # utilidades de audio ------------------------------------------------------------------
@@ -782,7 +783,7 @@ class App(tk.Tk):
             )
 
             self.q.put("→ Alineando…")
-            rows = build_rows(ref, hyp)
+            rows = [canonical_row(r) for r in build_rows(ref, hyp)]
             if self.use_wordcsv.get():
                 try:
                     from utils.resync_python_v2 import load_words_csv, resync_rows

--- a/tests/test_cli_resync.py
+++ b/tests/test_cli_resync.py
@@ -18,3 +18,4 @@ def test_cli_resync(tmp_path):
     out = tmp_path / "in.resync.json"
     data = json.loads(out.read_text())
     assert data[0][5] == "0.50"
+    assert data[0][7] == "hola"


### PR DESCRIPTION
## Summary
- keep ASR text when resyncing
- canonicalize rows before applying CSV timecodes
- adjust CLI resync test

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails to collect tests due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68824c72f280832a9611584da5554e79