### PR TITLE
Show original popup on playback

### DIFF
--- a/qc_app.py
+++ b/qc_app.py
@@ -481,8 +481,6 @@ class App(tk.Tk):
         if col == "#3":
             self._toggle_ok(item)
             return
-        if col in ("#7", "#8"):
-            self._show_text_popup(item, col)
         self._play_clip(item)
 
     def _play_clip(self, iid: str):
@@ -494,6 +492,7 @@ class App(tk.Tk):
             start = float(self.tree.set(iid, "tc"))
         except ValueError:
             return
+        self._show_text_popup(iid, "#7")
         # siguiente
         children = list(self.tree.get_children())
         idx = children.index(iid)


### PR DESCRIPTION
## Summary
- ensure double-click playback shows text from Original column
- display Original column popup whenever a clip is played

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688262677b9c832a83ef2fe7b3059759