### PR TITLE
Fix early audio cutoff

### DIFF
--- a/qc_app bak.py
+++ b/qc_app bak.py
@@ -30,14 +30,21 @@ from text_utils import read_script
 # utilidades de audio ------------------------------------------------------------------
 # --------------------------------------------------------------------------------------
 
+PLAYBACK_PAD = 0.3
+
+
 def play_interval(path: str, start: float, end: float | None) -> None:
-    """Reproduce *path* desde *start* (seg) hasta *end* (seg) con pygame."""
+    """Reproduce *path* desde *start* (seg) hasta *end* (seg) con pygame.
+
+    Incluye un margen ``PLAYBACK_PAD`` para evitar cortar el audio demasiado
+    pronto si los tiempos no son exactos.
+    """
 
     pygame.mixer.init()
     pygame.mixer.music.load(path)
     pygame.mixer.music.play(start=start)
     if end is not None:
-        ms = int(max(0.0, end - start) * 1000)
+        ms = int(max(0.0, end - start + PLAYBACK_PAD) * 1000)
         tk._default_root.after(ms, pygame.mixer.music.stop)
 
 

--- a/qc_app.py
+++ b/qc_app.py
@@ -31,14 +31,21 @@ from qc_utils import canonical_row
 # utilidades de audio ------------------------------------------------------------------
 # --------------------------------------------------------------------------------------
 
+PLAYBACK_PAD = 0.3
+
+
 def play_interval(path: str, start: float, end: float | None) -> None:
-    """Reproduce *path* desde *start* (seg) hasta *end* (seg) con pygame."""
+    """Reproduce *path* desde *start* (seg) hasta *end* (seg) con pygame.
+
+    Se añade un pequeño margen ``PLAYBACK_PAD`` para evitar que el audio se
+    corte demasiado pronto si los códigos de tiempo no son precisos.
+    """
 
     pygame.mixer.init()
     pygame.mixer.music.load(path)
     pygame.mixer.music.play(start=start)
     if end is not None:
-        ms = int(max(0.0, end - start) * 1000)
+        ms = int(max(0.0, end - start + PLAYBACK_PAD) * 1000)
         tk._default_root.after(ms, pygame.mixer.music.stop)
 
 

--- a/qc_app_adv.py
+++ b/qc_app_adv.py
@@ -33,14 +33,21 @@ from qc_utils import canonical_row
 # utilidades de audio ------------------------------------------------------------------
 # --------------------------------------------------------------------------------------
 
+PLAYBACK_PAD = 0.3
+
+
 def play_interval(path: str, start: float, end: float | None) -> None:
-    """Reproduce *path* desde *start* (seg) hasta *end* (seg) con pygame."""
+    """Reproduce *path* desde *start* (seg) hasta *end* (seg) con pygame.
+
+    Agrega un pequeño margen ``PLAYBACK_PAD`` para evitar cortes prematuros
+    cuando los códigos de tiempo no son precisos.
+    """
 
     pygame.mixer.init()
     pygame.mixer.music.load(path)
     pygame.mixer.music.play(start=start)
     if end is not None:
-        ms = int(max(0.0, end - start) * 1000)
+        ms = int(max(0.0, end - start + PLAYBACK_PAD) * 1000)
         tk._default_root.after(ms, pygame.mixer.music.stop)
 
 


### PR DESCRIPTION
## Summary
- ensure playback lasts slightly longer by padding the stop time

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68826912e348832aa420432af8bd59cf