### PR TITLE
Fix script reading and disable prompt features

### DIFF
--- a/qc_app.py
+++ b/qc_app.py
@@ -316,9 +316,7 @@ class App(tk.Tk):
 
             if self.use_wordcsv.get():
                 out = transcribe_word_csv(
-                    self.v_audio.get(),
-                    script_path=self.v_ref.get(),
-                    progress_queue=self.q,
+                    self.v_audio.get(), progress_queue=self.q
                 )
             else:
                 out = transcribe_file(

--- a/qc_app_adv.py
+++ b/qc_app_adv.py
@@ -276,10 +276,7 @@ class App(tk.Tk):
             from transcriber import transcribe_file, transcribe_word_csv
 
             if self.use_wordcsv.get():
-                out = transcribe_word_csv(
-                    self.v_audio.get(),
-                    script_path=self.v_ref.get(),
-                )
+                out = transcribe_word_csv(self.v_audio.get())
             else:
                 out = transcribe_file(self.v_audio.get(), script_path=self.v_ref.get())
             self.q.put(("SET_ASR", str(out)))

--- a/text_utils.py
+++ b/text_utils.py
@@ -102,56 +102,33 @@ def normalize(text: str, strip_punct: bool = True) -> str:
     return re.sub(r"\s+", " ", text).strip()
 
 
-# text_utils.py  – reemplaza la función completa
-
-from pathlib import Path
-import pdfplumber
 
 
 def read_script(path: str) -> str:
-    """Devuelve el texto de un PDF o TXT normalizado para alineamiento."""
+    """Return raw text from a PDF or TXT file without normalization."""
 
     p = Path(path)
 
-    # ── PDF ─────────────────────────────────────────────────────────────────────
     if p.suffix.lower() == ".pdf":
         with pdfplumber.open(p) as pdf:
             pages = [pg.extract_text() or "" for pg in pdf.pages]
         raw = "\n".join(pages)
         if not raw.strip():
             raise RuntimeError("No se pudo extraer texto del PDF; usa un TXT.")
-    else:
-        # ── TXT ─────────────────────────────────────────────────────────────────────
-        # 1. Intentamos utf-8 (lo ideal)
+        return raw
+
+    for enc in ("utf-8", "latin-1"):
         try:
-            raw = p.read_text(encoding="utf-8")  # sin errors="ignore" ❗
+            return p.read_text(encoding=enc)
         except UnicodeDecodeError:
-            # 2. Fallback rápido Latin-1 / Windows-1252 (común en textos antiguos)
-            try:
-                raw = p.read_text(encoding="latin-1")
-            except UnicodeDecodeError:
-                # 3. Último recurso: detección automática
-                try:
-                    import chardet  # pip install chardet
-                    data = p.read_bytes()
-                    enc = chardet.detect(data)["encoding"] or "latin-1"
-                    raw = data.decode(enc, errors="replace")  # nunca "ignore"
-                except Exception as exc:
-                    raise RuntimeError(f"No se pudo determinar la codificación: {exc}")
-
-    # ── NORMALIZACIÓN CRUCIAL ────────────────────────────────────────────────────
-    # Aplicar normalización básica manteniendo estructura de párrafos
-    lines = []
-    for line in raw.split('\n'):
-        line = line.strip()
-        if line:  # Solo procesar líneas no vacías
-            # Normalizar pero mantener algo de puntuación para el alineamiento
-            normalized = normalize(line, strip_punct=False)
-            if normalized:
-                lines.append(normalized)
-
-    # Unir con espacios, creando un texto continuo normalizado
-    return ' '.join(lines)
+            pass
+    try:
+        import chardet  # pip install chardet
+        data = p.read_bytes()
+        enc = chardet.detect(data)["encoding"] or "latin-1"
+        return data.decode(enc, errors="replace")
+    except Exception as exc:
+        raise RuntimeError(f"No se pudo determinar la codificación: {exc}")
 
 
 def token_equal(a: str, b: str) -> bool:

--- a/transcriber.py
+++ b/transcriber.py
@@ -15,7 +15,6 @@ import torch
 
 from text_utils import read_script, extract_word_list
 from alignment import build_rows
-from qc_utils import canonical_row
 
 try:
     from faster_whisper import WhisperModel
@@ -265,14 +264,10 @@ def transcribe_word_csv(
     *,
     test_mode: bool = False,
     use_vad: bool = True,
-    script_path: str | None = None,
     show_messagebox: bool = True,
     progress_queue: "queue.Queue" | None = None,
 ) -> Path:
-    """Transcribe ``file_path`` saving words CSV and plain text.
-
-    If ``script_path`` is provided it will guide Whisper using the script text.
-    """
+    """Transcribe ``file_path`` saving words CSV and plain text."""
 
     if not file_path:
         file_path = _select_file()
@@ -287,7 +282,6 @@ def transcribe_word_csv(
         Path(audio_path),
         test_mode=test_mode,
         use_vad=use_vad,
-        script_path=script_path,
         q=progress_queue,
     )
 
@@ -356,9 +350,8 @@ def main(argv: list[str] | None = None) -> None:
         if not args.input:
             parser.error("--resync-csv requires a QC JSON path")
         from utils.resync_python_v2 import load_words_csv, resync_rows
-        from qc_utils import canonical_row
-
         raw_rows = json.loads(Path(args.input).read_text(encoding="utf8"))
+        from qc_utils import canonical_row
         rows = [canonical_row(r) for r in raw_rows]
         csv_words, csv_tcs = load_words_csv(Path(args.resync_csv))
         resync_rows(rows, csv_words, csv_tcs)
@@ -390,8 +383,8 @@ def main(argv: list[str] | None = None) -> None:
         txt = transcribe_word_csv(args.input)
         ref = read_script(args.script)
         hyp = Path(txt).read_text(encoding="utf8", errors="ignore")
+        from qc_utils import canonical_row
         rows = [canonical_row(r) for r in build_rows(ref, hyp)]
-        from utils.resync_python_v2 import load_words_csv, resync_rows
 
         csv_path = Path(args.input).with_suffix(".words.csv")
         csv_words, csv_tcs = load_words_csv(csv_path)


### PR DESCRIPTION
## Summary
- revert `read_script` normalization so raw text is used
- remove hotword/initial prompt logic from `word_timed_transcriber_2`
- revert word CSV transcription to previous behavior
- update GUI apps to stop sending script to CSV transcriber

## Testing
- `flake8 text_utils.py transcriber.py utils/word_timed_transcriber_2.py qc_app.py qc_app_adv.py` *(fails: various style errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883c4763c34832a990f06a34a0f08ee