### PR TITLE
Add truncated take detection

### DIFF
--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -43,3 +43,12 @@ def test_build_rows_detect_repetition():
     rows = build_rows(ref, hyp)
     assert "||" in rows[0][5]
     assert rows[0][1] == "✅"
+
+
+def test_build_rows_truncated_take():
+    ref = "Nos los representantes del pueblo argentino"
+    hyp = "Nos los representantes nos nos los representantes del pueblo argentino"
+    rows = build_rows(ref, hyp)
+    assert "||" in rows[0][5]
+    parts = [p.strip() for p in rows[0][5].split("||")]
+    assert parts[-1].endswith("argentino")


### PR DESCRIPTION
## Summary
- improve `_find_takes` to detect partial repeated takes
- use the new parameter in `_apply_repetitions`
- test truncated take detection

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68877746064c832aa851344ef5548eca