### PR TITLE
Use alignment build_rows_wordlevel

### DIFF
--- a/tests/test_cli_wordalign.py
+++ b/tests/test_cli_wordalign.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 import sys
 import types
 
@@ -33,7 +32,8 @@ def test_cli_word_align(tmp_path, monkeypatch):
         return words_json
 
     monkeypatch.setattr(tr, "transcribe_wordlevel", fake_transcribe_wordlevel)
-    monkeypatch.setattr(tr, "build_rows_wordlevel", lambda ref, words: [[0, "", 0, 0, "hola", "hola"]])
+    import alignment
+    monkeypatch.setattr(alignment, "build_rows_wordlevel", lambda ref, js: [[0, "", 0, 0, "hola", "hola"]])
     monkeypatch.setattr(tr, "read_script", lambda p: "hola")
 
     tr.main([str(audio), "--script", str(script), "--word-align"])
@@ -41,4 +41,3 @@ def test_cli_word_align(tmp_path, monkeypatch):
     out = tmp_path / "aud.word.qc.json"
     data = json.loads(out.read_text())
     assert data[0][4] == "hola"
-

--- a/transcriber.py
+++ b/transcriber.py
@@ -15,6 +15,7 @@ import torch
 
 from text_utils import read_script, extract_word_list
 from alignment import build_rows
+import alignment
 
 try:
     from faster_whisper import WhisperModel
@@ -310,13 +311,6 @@ def transcribe_word_csv(
     return txt_path
 
 
-def build_rows_wordlevel(ref: str, words: list[dict]) -> list[list]:
-    """Build QC rows using ``words`` from :func:`transcribe_wordlevel`."""
-
-    text = " ".join(w.get("word", "") for w in words)
-    return build_rows(ref, text)
-
-
 def main(argv: list[str] | None = None) -> None:
     """CLI entry point."""
 
@@ -371,8 +365,8 @@ def main(argv: list[str] | None = None) -> None:
             detailed=True,
         )
         ref = read_script(args.script)
-        words = json.loads(Path(words_json).read_text(encoding="utf8"))
-        rows = build_rows_wordlevel(ref, words)
+        words_json_text = Path(words_json).read_text(encoding="utf8")
+        rows = alignment.build_rows_wordlevel(ref, words_json_text)
         base = Path(args.input).with_suffix("")
         out = base.with_suffix(".word.qc.json")
         out.write_text(json.dumps(rows, ensure_ascii=False, indent=2), encoding="utf8")


### PR DESCRIPTION
## Summary
- remove transcriber.build_rows_wordlevel helper
- call alignment.build_rows_wordlevel in CLI when word-align is requested
- update CLI test accordingly

## Testing
- `flake8 transcriber.py tests/test_cli_wordalign.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887906c0c04832abe0485aaa5b5b758