### PR TITLE
Improve resync interpolation

### DIFF
--- a/tests/test_cli_resync.py
+++ b/tests/test_cli_resync.py
@@ -1,7 +1,4 @@
 import json
-from pathlib import Path
-import sys
-import types
 
 from test_cli_wordalign import _get_transcriber
 
@@ -19,3 +16,23 @@ def test_cli_resync(tmp_path):
     data = json.loads(out.read_text())
     assert data[0][5] == "0.50"
     assert data[0][7] == "hola"
+
+
+def test_cli_resync_trailing_interpolate(tmp_path):
+    qc = tmp_path / "in.qc.json"
+    rows = [
+        [0, "", 0, 0.0, "hola", "hola"],
+        [1, "", 0, 0.0, "adios", "adios"],
+        [2, "", 0, 0.0, "gracias", "gracias"],
+    ]
+    qc.write_text(json.dumps(rows), encoding="utf8")
+    csv = tmp_path / "in.words.csv"
+    csv.write_text("0.0; hola\n3.0; extra\n", encoding="utf8")
+
+    tr = _get_transcriber()
+    tr.main([str(qc), "--resync-csv", str(csv)])
+
+    out = tmp_path / "in.resync.json"
+    data = json.loads(out.read_text())
+    assert data[1][5] == "1.50"
+    assert data[2][5] == "3.00"


### PR DESCRIPTION
## Summary
- interpolate trailing rows in `resync_rows` using final CSV time
- warn when many rows lack a mapping
- test trailing interpolation via CLI

## Testing
- `flake8 tests/test_cli_resync.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688794b28550832ab030790138268bd0