### PR TITLE
Handle ASR takes as metadata

### DIFF
--- a/qc_utils.py
+++ b/qc_utils.py
@@ -74,7 +74,7 @@ def canonical_row(row: List) -> List:
     with empty strings so that the output always has either 8 or 9 elements.
     """
     if len(row) >= 9:
-        return row[:9]
+        return row
     if len(row) == 8:
         return row
     if len(row) == 7:

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -41,7 +41,9 @@ def test_build_rows_detect_repetition():
     ref = "Hola mundo"
     hyp = "Hola mundo hola mundo hola mundo"
     rows = build_rows(ref, hyp)
-    assert "||" in rows[0][5]
+    assert rows[0][5] == "hola mundo"
+    assert len(rows[0]) > 6
+    assert len(rows[0][6]) > 1
     assert rows[0][1] == "✅"
 
 
@@ -49,6 +51,6 @@ def test_build_rows_truncated_take():
     ref = "Nos los representantes del pueblo argentino"
     hyp = "Nos los representantes nos nos los representantes del pueblo argentino"
     rows = build_rows(ref, hyp)
-    assert "||" in rows[0][5]
-    parts = [p.strip() for p in rows[0][5].split("||")]
-    assert parts[-1].endswith("argentino")
+    assert rows[0][5].endswith("argentino")
+    assert len(rows[0]) > 6
+    assert rows[0][6][-1].endswith("argentino")


### PR DESCRIPTION
## Summary
- keep alternative ASR takes in a separate column instead of embedded `||` markers
- preserve extra columns in `canonical_row`
- update tests for new structure

## Testing
- `flake8 alignment.py qc_utils.py tests/test_alignment.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68879d260dcc832abafbf5be68527532