### PR TITLE
Fix clean_json_text to keep digits

### DIFF
--- a/tests/test_clean_json_text.py
+++ b/tests/test_clean_json_text.py
@@ -1,0 +1,13 @@
+import utils.clean_json_text as cjt
+
+
+def test_clean_text_keeps_digits():
+    assert cjt._clean_text("abc123") == "abc123"
+    assert cjt._clean_text("1 2 3!") == "1 2 3"
+
+
+def test_clean_rows_keeps_digits():
+    rows = [[0, "", 0, 0, "uno 2 tres", "4 cinco 6"]]
+    cjt.clean_rows(rows)
+    assert rows[0][-2] == "uno 2 tres"
+    assert rows[0][-1] == "4 cinco 6"

--- a/utils/clean_json_text.py
+++ b/utils/clean_json_text.py
@@ -9,8 +9,8 @@ from pathlib import Path
 
 
 def _clean_text(text: str) -> str:
-    """Return ``text`` keeping only letters and spaces."""
-    cleaned = ''.join(c for c in text if c.isalpha() or c.isspace())
+    """Return ``text`` keeping only letters, digits and spaces."""
+    cleaned = "".join(c for c in text if c.isalnum() or c.isspace())
     return re.sub(r"\s+", " ", cleaned).strip()
 
 


### PR DESCRIPTION
## Summary
- preserve numbers in clean_json_text
- test that numbers remain after cleaning

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887bc983c4c832a912bb5c910a5b947