### PR TITLE
Ensure OK column auto-saves

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The updated rows are written to `myaudio.resync.json` next to the original file.
 ## Manual review
 
 Double-click the **OK** column in the results table to mark or unmark a row as
-reviewed. Use the **Guardar JSON** button to save the current table so these
+reviewed. The table is saved automatically to the loaded JSON file so these
 marks persist. Loading a previously saved file that includes an **OK** column
 will restore the review status for each row.
 

--- a/qc_app.py
+++ b/qc_app.py
@@ -640,6 +640,7 @@ class App(tk.Tk):
             self.ok_rows.add(line_id)
         else:
             self.ok_rows.discard(line_id)
+        self.save_json()
 
     def _popup_mark_ok(self, iid: str, win: tk.Toplevel) -> None:
         self.tree.set(iid, "OK", "OK")
@@ -649,6 +650,7 @@ class App(tk.Tk):
         except Exception:
             pass
         win.destroy()
+        self.save_json()
 
     def _update_metrics(self, iid: str) -> None:
         """Recalculate flag and WER after modifying text."""

--- a/tests/test_gui_autosave_ok.py
+++ b/tests/test_gui_autosave_ok.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import tempfile
+import json
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from qc_app import App  # noqa: E402
+
+if not os.environ.get("DISPLAY"):
+    import pytest
+    pytest.skip("no display", allow_module_level=True)
+
+
+def test_autosave_on_toggle_ok():
+    app = App()
+    try:
+        row = [0, "", "", "", 0.0, "0.0", "hola", "hola"]
+        app.tree.insert("", "end", values=row)
+        item = app.tree.get_children()[0]
+        with tempfile.TemporaryDirectory() as td:
+            path = os.path.join(td, "tmp.json")
+            app.v_json.set(path)
+            app._toggle_ok(item)
+            data = json.loads(open(path, encoding="utf8").read())
+            assert data[0][2] == "OK"
+    finally:
+        app.destroy()
+


### PR DESCRIPTION
## Summary
- auto-save JSON when toggling OK status in qc_app
- update README to clarify automatic saving
- add regression test for OK autosave

## Testing
- `pytest -q`
- `flake8` *(fails: many style violations)*

------
https://chatgpt.com/codex/tasks/task_e_688a2478c97c832a9b69986491b0f56c