### PR TITLE
Fix ASR truncation when building alignment rows

### DIFF
--- a/alignment.py
+++ b/alignment.py
@@ -195,6 +195,9 @@ def build_rows(ref: str, hyp: str) -> List[List]:
                 else:
                     break
 
+            while h_start > 0 and (h_start - 1) not in consumed_h:
+                h_start -= 1
+
             consumed_h.update(range(h_start, h_end))
             asr_line = " ".join(hyp_tok[h_start:h_end])
         else:
@@ -221,6 +224,11 @@ def build_rows(ref: str, hyp: str) -> List[List]:
 
         rows.append([line_id, flag, round(wer_val * 100, 1), dur, orig_line, asr_line])
         line_id += 1
+
+    unused = [i for i in range(len(hyp_tok)) if i not in consumed_h]
+    if unused:
+        extra = " ".join(hyp_tok[min(unused):])
+        rows[-1][5] = (rows[-1][5] + " " + extra).strip()
 
     return refine_segments(rows)
 
@@ -421,6 +429,8 @@ def build_rows_wordlevel(ref: str, asr_word_json: str) -> List[List]:
         if h_idxs:
             h_start = min(h_idxs)
             h_end = max(h_idxs) + 1
+            while h_start > 0 and (h_start - 1) not in consumed_h:
+                h_start -= 1
             consumed_h.update(range(h_start, h_end))
             asr_line = " ".join(w["norm"] for w in words[h_start:h_end])
             start_time = words[h_start]["start"]
@@ -450,5 +460,10 @@ def build_rows_wordlevel(ref: str, asr_word_json: str) -> List[List]:
 
         rows.append([line_id, flag, round(wer_val * 100, 1), dur, orig_line, asr_line])
         line_id += 1
+
+    unused = [i for i in range(len(hyp_tok)) if i not in consumed_h]
+    if unused:
+        extra = " ".join(w["norm"] for w in words[min(unused):])
+        rows[-1][5] = (rows[-1][5] + " " + extra).strip()
 
     return _apply_repetitions(rows)

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -1,6 +1,7 @@
 import json
 
 from alignment import build_rows, build_rows_wordlevel
+from text_utils import normalize
 
 
 def test_build_rows_basic():
@@ -53,3 +54,11 @@ def test_build_rows_truncated_take():
     assert rows[0][5].endswith("argentino")
     assert len(rows[0]) > 6
     assert rows[0][6][-1].endswith("argentino")
+
+
+def test_build_rows_no_truncation():
+    ref = "Hola mundo. Adios."
+    hyp = "Hola hola mundo. Adios."
+    rows = build_rows(ref, hyp)
+    assembled = " ".join(r[5] for r in rows)
+    assert normalize(assembled, strip_punct=False).split() == normalize(hyp, strip_punct=False).split()


### PR DESCRIPTION
## Summary
- prevent dropping unmatched ASR words when aligning
- append leftover ASR tokens to the last row
- cover no-truncation scenario with new test

## Testing
- `flake8 alignment.py tests/test_alignment.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a4b8f9e74832ab48eac789c432939