### PR TITLE
Improve default transcription output

### DIFF
--- a/qc_app.py
+++ b/qc_app.py
@@ -88,7 +88,6 @@ class App(tk.Tk):
         self.v_audio = tk.StringVar(self)
         self.v_json  = tk.StringVar(self)
         self.ai_one  = tk.BooleanVar(self, value=False)
-        self.use_wordcsv = tk.BooleanVar(self, value=False)
 
         # Estados internos
         self.q:   queue.Queue = queue.Queue()
@@ -132,7 +131,6 @@ class App(tk.Tk):
                         ("Media", "*.mp3;*.wav;*.m4a;*.flac;*.ogg;*.aac;*.mp4"))
 
         ttk.Button(top, text="Transcribir", command=self.transcribe).grid(row=2, column=3, padx=6)
-        ttk.Checkbutton(top, text="CSV palabras", variable=self.use_wordcsv).grid(row=2, column=4, padx=4)
         ttk.Button(top, text="Procesar", width=11, command=self.launch).grid(row=0, column=3, rowspan=2, padx=6)
 
         ttk.Label(top, text="JSON:").grid(row=3, column=0, sticky="e")
@@ -312,18 +310,13 @@ class App(tk.Tk):
 
     def _transcribe_worker(self) -> None:
         try:
-            from transcriber import transcribe_file, transcribe_word_csv
+            from transcriber import transcribe_word_csv
 
-            if self.use_wordcsv.get():
-                out = transcribe_word_csv(
-                    self.v_audio.get(), progress_queue=self.q
-                )
-            else:
-                out = transcribe_file(
-                    self.v_audio.get(),
-                    script_path=self.v_ref.get(),
-                    progress_queue=self.q,
-                )
+            out = transcribe_word_csv(
+                self.v_audio.get(),
+                script_path=self.v_ref.get(),
+                progress_queue=self.q,
+            )
             self.q.put(("SET_ASR", str(out)))
             self.q.put(f"✔ Transcripción guardada en {out}")
         except BaseException as exc:  # noqa: BLE001 - catch SystemExit too
@@ -1004,7 +997,7 @@ class App(tk.Tk):
                 resync_rows(rows, csv_words, csv_tcs)
             else:
                 csv_path = Path(self.v_audio.get()).with_suffix(".words.csv")
-                if self.use_wordcsv.get() or csv_path.exists():
+                if csv_path.exists():
                     try:
                         from utils.resync_python_v2 import load_words_csv, resync_rows
                         csv_words, csv_tcs = load_words_csv(csv_path)

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -36,3 +36,10 @@ def test_extract_word_list_basic():
     words = text_utils.extract_word_list(txt)
     # 'raro' should appear before common stop words
     assert words[0] == "hola" and "raro" in words
+
+
+def test_extract_word_list_proper_names():
+    txt = "El senor Echeverriano saludo a Maria y Jose."  # keep accents normalized
+    words = text_utils.extract_word_list(txt, max_words=10)
+    assert "echeverriano" in words
+    assert "maria" in words

--- a/tests/test_transcribe_worker_error.py
+++ b/tests/test_transcribe_worker_error.py
@@ -17,9 +17,9 @@ def test_transcribe_worker_systemexit(monkeypatch, mod_name):
     mod = importlib.import_module(mod_name)
     app = mod.App()
     try:
-        def fake_transcribe_file(*a, **k):
+        def fake_transcribe(*a, **k):
             raise SystemExit("fail")
-        monkeypatch.setattr("transcriber.transcribe_file", fake_transcribe_file)
+        monkeypatch.setattr("transcriber.transcribe_word_csv", fake_transcribe)
         called = {}
         def fake_show_error(title, exc):
             called["msg"] = str(exc)

--- a/text_utils.py
+++ b/text_utils.py
@@ -234,7 +234,7 @@ def find_anchor_trigrams(
 
 
 def extract_word_list(text: str, max_words: int = 50) -> List[str]:
-    """Return frequent non-stopwords from ``text`` for ASR prompting."""
+    """Return frequent and noteworthy words from ``text`` for ASR prompting."""
 
     tokens = normalize(text).split()
     counts = Counter(t for t in tokens if t not in STOP and len(t) > 3)
@@ -245,4 +245,25 @@ def extract_word_list(text: str, max_words: int = 50) -> List[str]:
     ordered = sorted(
         counts.items(), key=lambda x: (-x[1], first_pos.get(x[0], 0))
     )
-    return [w for w, _ in ordered[:max_words]]
+
+    proper_raw = re.findall(r"\b[A-ZÁÉÍÓÚÑ][\wÁÉÍÓÚÑáéíóúñ]*\b", text)
+    proper_tokens: List[str] = []
+    seen: set[str] = set()
+    for tok in proper_raw:
+        norm = normalize(tok)
+        if len(norm) > 3 and norm not in STOP and norm not in seen:
+            proper_tokens.append(norm)
+            seen.add(norm)
+
+    result: List[str] = []
+    for tok in proper_tokens:
+        result.append(tok)
+        if len(result) >= max_words:
+            return result
+
+    for tok, _ in ordered:
+        if tok not in result:
+            result.append(tok)
+        if len(result) >= max_words:
+            break
+    return result[:max_words]


### PR DESCRIPTION
## Summary
- always use `transcribe_word_csv` in the QC apps
- update CLI to output word CSV
- enhance `extract_word_list` to include capitalized names
- adjust tests for new behaviour

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a52480924832ab9a09ed4be221c33