### PR TITLE
Fix start time handling in alignment

### DIFF
--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -35,7 +35,7 @@ def test_build_rows_wordlevel_basic():
     }
     rows = build_rows_wordlevel(ref, json.dumps(data))
     assert rows[0][1] == "✅"
-    assert rows[0][3] == 1.0
+    assert rows[0][3] == 0.0
 
 
 def test_build_rows_detect_repetition():


### PR DESCRIPTION
## Summary
- compute timecodes as start times instead of segment duration
- accumulate time through `refine_segments`
- update alignment word-level logic
- adjust related test

## Testing
- `flake8 alignment.py tests/test_alignment.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b7661cc10832ab70dc7abce825625