### PR TITLE
Fix timing regression in alignment

### DIFF
--- a/alignment.py
+++ b/alignment.py
@@ -176,8 +176,6 @@ def build_rows(ref: str, hyp: str) -> List[List]:
     rows = []
     consumed_h = set()
     line_id = 0
-    current_time = 0.0
-    current_time = 0.0
 
     # divide reference into sentence spans for cleaner rows
     text_norm = normalize(ref, strip_punct=False)
@@ -248,11 +246,10 @@ def build_rows(ref: str, hyp: str) -> List[List]:
         else:
             threshold = 0.20 if len(ref_tokens) < 5 else WARN_WER
             flag = "✅" if wer_val <= threshold else ("⚠️" if wer_val <= 0.20 else "❌")
-        dur = len(asr_line.split()) / 3.0
+        dur = round(len(asr_line.split()) / 3.0, 2)
 
-        rows.append([line_id, flag, round(wer_val * 100, 1), round(current_time, 2), orig_line, asr_line])
+        rows.append([line_id, flag, round(wer_val * 100, 1), dur, orig_line, asr_line])
         line_id += 1
-        current_time += dur
 
     unused = [i for i in range(len(hyp_tok)) if i not in consumed_h]
     if unused:
@@ -405,11 +402,9 @@ def refine_segments(rows: List[List], max_shift: int = 2) -> List[List]:
         r[1] = flag
         r[2] = round(wer_val * 100, 1)
 
-    time_pos = 0.0
     for r in rows:
         hyp_tokens = r[5].split()
-        r[3] = round(time_pos, 2)
-        time_pos += len(hyp_tokens) / 3.0
+        r[3] = round(len(hyp_tokens) / 3.0, 2)
 
     return _apply_repetitions(rows)
 
@@ -473,11 +468,9 @@ def build_rows_wordlevel(ref: str, asr_word_json: str) -> List[List]:
             asr_line = " ".join(w["norm"] for w in words[h_start:h_end])
             start_time = words[h_start]["start"]
             end_time = words[h_end - 1]["end"]
-            dur = end_time - start_time
-            current_time = start_time
+            dur = round(end_time - start_time, 2)
         else:
             asr_line = ""
-            start_time = current_time
             dur = 0.0
 
         orig_line = " ".join(block)
@@ -498,9 +491,8 @@ def build_rows_wordlevel(ref: str, asr_word_json: str) -> List[List]:
             threshold = 0.20 if len(ref_tokens) < 5 else WARN_WER
             flag = "✅" if wer_val <= threshold else ("⚠️" if wer_val <= 0.20 else "❌")
 
-        rows.append([line_id, flag, round(wer_val * 100, 1), round(start_time, 2), orig_line, asr_line])
+        rows.append([line_id, flag, round(wer_val * 100, 1), dur, orig_line, asr_line])
         line_id += 1
-        current_time = start_time + dur
 
     unused = [i for i in range(len(hyp_tok)) if i not in consumed_h]
     if unused:

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -35,7 +35,7 @@ def test_build_rows_wordlevel_basic():
     }
     rows = build_rows_wordlevel(ref, json.dumps(data))
     assert rows[0][1] == "✅"
-    assert rows[0][3] == 0.0
+    assert rows[0][3] == 1.0
 
 
 def test_build_rows_detect_repetition():


### PR DESCRIPTION
## Summary
- compute segment durations instead of start times
- update tests for restored duration handling

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b7ff9a60c832abba3e6ed0c266959