### PR TITLE
Fix alignment resync prev_idx bug

### DIFF
--- a/utils/resync.py
+++ b/utils/resync.py
@@ -83,6 +83,7 @@ def _align_chunk(j_words: List[str], c_words: List[str]) -> List[int]:
             for k in range(i2 - i1):
                 mapping[i1 + k] = j1 + k
     last = -1
+    prev_idx = -1
     for idx, val in enumerate(mapping):
         if val != -1:
             if last == -1:

--- a/utils/resync_python_v2.py
+++ b/utils/resync_python_v2.py
@@ -94,6 +94,7 @@ def align_chunk(j_words: List[str], c_words: List[str]) -> List[int]:
                 mapping[i1+k]=j1+k
     # rellenar huecos linealmente
     last=-1
+    prev_idx=-1
     for idx,val in enumerate(mapping):
         if val!=-1:
             # propagar hacia atrás


### PR DESCRIPTION
## Summary
- fix undefined `prev_idx` used in resync helpers

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b8699f3c0832a8d7bfe9df16cc608