### PR TITLE
Fix tc column sequential timing

### DIFF
--- a/alignment.py
+++ b/alignment.py
@@ -263,7 +263,18 @@ def build_rows(ref: str, hyp: str) -> List[List]:
             extra,
         ])
 
-    return refine_segments(rows)
+    rows = refine_segments(rows)
+
+    start_time = 0.0
+    for r in rows:
+        try:
+            dur = float(r[3])
+        except Exception:
+            dur = 0.0
+        r[3] = round(start_time, 2)
+        start_time += dur
+
+    return rows
 
 
 def _find_takes(

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -38,6 +38,15 @@ def test_build_rows_wordlevel_basic():
     assert rows[0][3] == 0.0
 
 
+def test_build_rows_tc_sequential():
+    ref = "Uno dos. Tres cuatro cinco."
+    hyp = "Uno dos tres cuatro cinco"
+    rows = build_rows(ref, hyp)
+    tcs = [r[3] for r in rows]
+    assert tcs == sorted(tcs)
+    assert tcs[0] == 0.0
+
+
 def test_build_rows_detect_repetition():
     ref = "Hola mundo"
     hyp = "Hola mundo hola mundo hola mundo"


### PR DESCRIPTION
## Summary
- ensure `build_rows` outputs sequential start times
- test that tc values increase sequentially

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ba85b2f54832a980ff7a2aa3d14b8